### PR TITLE
[codex] use current core physics interface

### DIFF
--- a/SRC/anomalous_transport/utils_anomalous_transport_mod.f90
+++ b/SRC/anomalous_transport/utils_anomalous_transport_mod.f90
@@ -555,7 +555,7 @@ subroutine scan_anomalous_transport
         call apply_phi_perturbation(eps_Phi)
 
         ! Recompute tetrahedron physics with updated phi_elec
-        call make_tetra_physics(coord_system, ipert, boole_keep_phi_elec=.true.)
+        call make_tetra_physics(coord_system, ipert, i_option=12)
 
         ! Generate filename for this scan point
         select case(in%i_scan_option)

--- a/SRC/utils_self_consistent_ef_mod.f90
+++ b/SRC/utils_self_consistent_ef_mod.f90
@@ -458,8 +458,8 @@ subroutine perform_electric_potential_update(i)
 
     phi_elec = phi_elec + ep%phi_elec_from_rho
 
-    !boole_keep_phi_elec=.true. prevents make_tetra_physics from overwriting phi_elec
-    call make_tetra_physics(coord_system,ipert,boole_keep_phi_elec=.true.)
+    !i_option=12 prevents make_tetra_physics from overwriting phi_elec
+    call make_tetra_physics(coord_system, ipert, i_option=12)
 
     if (i.gt.0) call print_data(i)
 


### PR DESCRIPTION
## Summary
Update `GORILLA_APPLETS` to use the current tetra-physics rebuild interface exposed by the shared core modules.

## Root Cause
`GORILLA_APPLETS` still called `make_tetra_physics(..., boole_keep_phi_elec=.true.)`, but the current core interface now keeps externally prepared `phi_elec` via `i_option=12`. That stale keyword use breaks the applets build against current `GORILLA` `main`.

## What Changed
- replaced the obsolete `boole_keep_phi_elec` call sites with `i_option=12`
- aligned both the anomalous transport rebuild path and the self-consistent electric-field update path with the current core API

## Impact
This restores the applets side of the shared interface so the paired core fix can compile the full `GORILLA_APPLETS` executable again.

## Verification

### Test fails on main
```text
$ make -C /home/ert/code/GORILLA-dev/GORILLA_APPLETS
...
/home/ert/code/GORILLA-dev/GORILLA_APPLETS/SRC/anomalous_transport/utils_anomalous_transport_mod.f90:558:73:
Error: Keyword argument 'boole_keep_phi_elec' at (1) is not in the procedure
/home/ert/code/GORILLA-dev/GORILLA_APPLETS/SRC/utils_self_consistent_ef_mod.f90:462:67:
Error: Keyword argument 'boole_keep_phi_elec' at (1) is not in the procedure
...
ninja: build stopped: subcommand failed.
make: *** [Makefile:17: build] Error 1
```

### Test passes after fix
```text
$ make -C /home/ert/code/GORILLA-dev/GORILLA
...
[97/98] Linking Fortran static library SRC/libGORILLA.a
[98/98] Linking Fortran executable test_gorilla_main.x
make: Leaving directory '/home/ert/code/GORILLA-dev/GORILLA'

$ make -C /home/ert/code/GORILLA-dev/GORILLA_APPLETS
...
[161/162] Linking Fortran static library SRC/libGORILLA_APPLETS.a
[162/162] Linking Fortran executable gorilla_applets_main.x
make: Leaving directory '/home/ert/code/GORILLA-dev/GORILLA_APPLETS'
```
