### PR TITLE
Guard single-species transport tracing

### DIFF
--- a/SRC/utils_self_consistent_ef_mod.f90
+++ b/SRC/utils_self_consistent_ef_mod.f90
@@ -321,7 +321,7 @@ subroutine orbit_timestep_gorilla_self_consistent_ef(x,vpar,vperp,t,particle_sta
                     start%weight(n, species)
             end if
         endif
-        if ((.not.in%boole_static_ne).and.(species.eq.1)) then
+        if ((.not.in%boole_static_ne).and.(species.eq.1).and.(in%n_species.ge.2)) then
             start%x(:,n,2) = start%x(:,n,1)
             start%weight(n,2) = start%weight(n,1)
         endif 


### PR DESCRIPTION
## Summary

This PR is the third layer in the transport-fitting stack.

It guards the single-species tracing path used by the electron transport comparison so the global/local workflow fails cleanly instead of wandering into invalid start states.

## Scope

This is intentionally small and isolated because it fixes a concrete runtime issue discovered while exercising the local comparison workflow.

## Verification

```bash
$ make -C /home/ert/code/GORILLA-dev/GORILLA_APPLETS test
100% tests passed, 0 tests failed out of 1
```
