### PR TITLE
Find netCDF via nf-config/nc-config on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,41 @@ enable_language(Fortran)
 if(UNIX AND NOT APPLE)
   include_directories(/usr/include)
 elseif(APPLE)
-  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-    include_directories(/opt/local/include)
-  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-    include_directories(/usr/local/include)
+  # Locate netCDF via nf-config / nc-config so the build works with either
+  # Homebrew or MacPorts instead of assuming a fixed prefix. netCDF-Fortran
+  # (libnetcdff, the .mod) and netCDF-C (libnetcdf) live under different
+  # prefixes on Homebrew, so query both. Fall back to the common prefixes
+  # when the config tools are not on PATH.
+  find_program(NF_CONFIG nf-config)
+  find_program(NC_CONFIG nc-config)
+  if(NF_CONFIG)
+    execute_process(COMMAND ${NF_CONFIG} --includedir
+                    OUTPUT_VARIABLE NETCDF_FORTRAN_INCLUDEDIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${NF_CONFIG} --prefix
+                    OUTPUT_VARIABLE NETCDF_FORTRAN_PREFIX
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    include_directories(${NETCDF_FORTRAN_INCLUDEDIR})
+    link_directories(${NETCDF_FORTRAN_PREFIX}/lib)
+  endif()
+  if(NC_CONFIG)
+    execute_process(COMMAND ${NC_CONFIG} --includedir
+                    OUTPUT_VARIABLE NETCDF_C_INCLUDEDIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${NC_CONFIG} --libdir
+                    OUTPUT_VARIABLE NETCDF_C_LIBDIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    include_directories(${NETCDF_C_INCLUDEDIR})
+    link_directories(${NETCDF_C_LIBDIR})
+  endif()
+  if(NOT NF_CONFIG AND NOT NC_CONFIG)
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+      include_directories(/opt/homebrew/include /opt/local/include)
+      link_directories(/opt/homebrew/lib /opt/local/lib)
+    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+      include_directories(/usr/local/include)
+      link_directories(/usr/local/lib)
+    endif()
   endif()
 endif()
 
@@ -23,10 +54,6 @@ find_package(netCDF REQUIRED)
 
 add_compile_options(-g -fbacktrace -ffpe-trap=zero,overflow,invalid -fbounds-check -fopenmp)
 add_link_options(-g -fbacktrace -ffpe-trap=zero,overflow,invalid -fbounds-check -fopenmp)
-
-if(APPLE)
-  add_link_options(-L/opt/local/lib)
-endif()
 
 add_subdirectory(SRC)
 add_subdirectory(SRC_CORE)


### PR DESCRIPTION
## Problem

The `APPLE` branch of `CMakeLists.txt` hardcoded the MacPorts prefix
`/opt/local` for include and link directories. On a Homebrew toolchain the
netCDF-Fortran module and libraries live elsewhere, so the build fails to find
`netcdf.mod` (and then `libnetcdf`).

## Change

Query `nf-config` (netCDF-Fortran) and `nc-config` (netCDF-C) for their include
and library directories instead of assuming a fixed prefix. This resolves
correctly under both Homebrew and MacPorts. The previous fixed prefixes remain
only as a fallback when neither tool is on `PATH`. netCDF-Fortran and netCDF-C
have separate prefixes on Homebrew, so both are queried.

The Linux path (`/usr/include`) is unchanged.

## Verification

Apple Silicon, Homebrew toolchain (gfortran 15, netcdf-fortran 4.6.2,
netcdf 4.9.3), configured with only the Fortran compiler set.

Before (stock `CMakeLists.txt`), during compilation of the core:

```
Fatal Error: Cannot open module file 'netcdf.mod' for reading at (1): No such file or directory
ninja: build stopped: subcommand failed.
```

After this change, the same clean configure and build:

```
CFG_OK
BUILD_OK
-rwxr-xr-x  1 ert  staff  1803992 BUILD/gorilla_applets_main.x
BINARY_OK
```