### PR TITLE
use newunit for all file unit allocation

### DIFF
--- a/SRC/alpha_lifetime_gorilla_mod.f90
+++ b/SRC/alpha_lifetime_gorilla_mod.f90
@@ -23,9 +23,11 @@
 !
         subroutine load_alpha_lifetime_inp()
 !
-            open(unit=71, file='alpha_lifetime.inp', status='unknown')
-            read(71,nml=alpha_lifetimenml)
-            close(71)
+            integer :: inp_unit
+!
+            open(newunit=inp_unit, file='alpha_lifetime.inp', status='unknown')
+            read(inp_unit,nml=alpha_lifetimenml)
+            close(inp_unit)
 
             print *,'GORILLA: Loaded input data from alpha_lifetime.inp'
 !
@@ -38,7 +40,7 @@
             integer, intent(in)     :: n_particles
             integer,dimension(:), allocatable :: seed
             double precision, dimension(:), allocatable :: rd_seed
-            integer :: j,n
+            integer :: j,n,seed_unit
 !
             allocate(rd_start_position(n_particles))
             allocate(rd_start_pitchpar(n_particles))
@@ -59,16 +61,16 @@
                     seed = int(rd_seed*10.d0)
                     deallocate(rd_seed)
 !
-                    open(85,file='seed.inp')
-                    write(85,*) n
-                    write(85,*) seed
-                    close(85)
+                    open(newunit=seed_unit,file='seed.inp')
+                    write(seed_unit,*) n
+                    write(seed_unit,*) seed
+                    close(seed_unit)
                 case(2) !Load seed
-                    open(unit = 85, file='seed.inp', status='old',action = 'read')
-                    read(85,*) n
+                    open(newunit = seed_unit, file='seed.inp', status='old',action = 'read')
+                    read(seed_unit,*) n
                     allocate(seed(n))
-                    read(85,*) seed
-                    close(85)
+                    read(seed_unit,*) seed
+                    close(seed_unit)
             end select
 !
             CALL RANDOM_SEED (PUT=seed)
@@ -111,7 +113,7 @@
 !
             double precision :: vmod,pitchpar,vpar,vperp,t_remain,t_confined,tau_out_can
             integer :: kpart,i,n,ind_tetr,iface,n_lost_particles,ierr
-            integer :: n_start, n_end, i_part
+            integer :: n_start, n_end, i_part, alpha_unit
             double precision, dimension(3) :: x_rand_beg,x
             double precision, dimension(:), allocatable :: xi
             logical :: boole_initialized,boole_particle_lost
@@ -162,7 +164,7 @@
 !------------------------------------------------------------------------------------------------------------!
 !
             !Open file for writing alpha_life_time_gorilla
-            open(99,file=filename_alpha_lifetime)
+            open(newunit=alpha_unit,file=filename_alpha_lifetime)
 !
 
             !Precompute random numbers
@@ -185,7 +187,7 @@
 !
             !$OMP PARALLEL DEFAULT(NONE) &
             !$OMP& SHARED(n_particles,pos_fluxtv_mat,xi,n_lost_particles,kpart,vmod,time_step,i_integrator_type, &
-            !$OMP& dtau,dtaumin,rd_start_position,rd_start_pitchpar,boole_random_precalc,n_start,n_end) &
+            !$OMP& dtau,dtaumin,rd_start_position,rd_start_pitchpar,boole_random_precalc,n_start,n_end,alpha_unit) &
             !$OMP& PRIVATE(n,boole_particle_lost,i,x_rand_beg,x,pitchpar,vpar,vperp,boole_initialized, &
             !$OMP& ind_tetr,iface,t_remain,t_confined,z,ierr,tau_out_can)
             !$OMP DO
@@ -257,8 +259,8 @@ print *, kpart, ' / ', n_particles, 'particle: ', n, 'thread: ' !, omp_get_threa
 !
                         !Write results in file
                         !$omp critical
-                            !write(99,*) n, boole_particle_lost , x_rand_beg ,pitchpar,x(1),t_confined
-                            write(99,*) t_confined
+                            !write(alpha_unit,*) n, boole_particle_lost , x_rand_beg ,pitchpar,x(1),t_confined
+                            write(alpha_unit,*) t_confined
                         !$omp end critical
 !
                     case(2)
@@ -285,10 +287,11 @@ print *, kpart, ' / ', n_particles, 'particle: ', n, 'thread: ' !, omp_get_threa
             !$OMP END DO
             !$OMP END PARALLEL
 !
-!            close(99)
+            close(alpha_unit)
 print *, 'Number of lost particles',n_lost_particles
-!open(99,file='confined_fraction.dat')
-!write(99,*) 1.d0-dble(n_lost_particles)/dble(n_particles)
+!open(alpha_unit,file='confined_fraction.dat')
+!write(alpha_unit,*) 1.d0-dble(n_lost_particles)/dble(n_particles)
+!close(alpha_unit)
 !
             !Deallocate random numbers
             if(boole_random_precalc) then

--- a/SRC/flux_deviation_mod.f90
+++ b/SRC/flux_deviation_mod.f90
@@ -23,7 +23,7 @@
             integer(kind=8),intent(in) :: n_time_steps
             integer,dimension(:), allocatable :: seed
             double precision, dimension(:), allocatable :: rd_seed
-            integer :: j,n
+            integer :: j,n,seed_unit
 !
             allocate(rd_start_position(n_particles))
             allocate(rd_start_pitchpar(n_particles))
@@ -45,16 +45,16 @@
                     seed = int(rd_seed*10.d0)
                     deallocate(rd_seed)
 !
-                    open(85,file='seed.inp')
-                    write(85,*) n
-                    write(85,*) seed
-                    close(85)
+                    open(newunit=seed_unit,file='seed.inp')
+                    write(seed_unit,*) n
+                    write(seed_unit,*) seed
+                    close(seed_unit)
                 case(2) !Load seed
-                    open(unit = 85, file='seed.inp', status='old',action = 'read')
-                    read(85,*) n
+                    open(newunit = seed_unit, file='seed.inp', status='old',action = 'read')
+                    read(seed_unit,*) n
                     allocate(seed(n))
-                    read(85,*) seed
-                    close(85)
+                    read(seed_unit,*) seed
+                    close(seed_unit)
             end select
 !
             CALL RANDOM_SEED (PUT=seed)
@@ -115,7 +115,7 @@
 !
             integer :: i,j,k,l,n,o,nskip,ierr,iface,ind_tetr,iper
             integer :: counter_tetrahedron_passes, counter_lost_particles,counter_mappings
-            integer :: n_surviving
+            integer :: n_surviving, n_lost_unit
             logical :: boole_t_finished
             logical, dimension(:), allocatable :: lost_particles
             double precision, dimension(:,:), allocatable :: psi_mat,psi_vec,delta_psi_mat,delta_psi_vec
@@ -627,9 +627,9 @@
 !
             print *, 'Number of lost particles in Monte Carlo simulation', counter_lost_particles
 !
-            open(unit=202,file='n_lost_particles.dat',status='unknown')
-            write(202,*) counter_lost_particles
-            close(202)
+            open(newunit=n_lost_unit,file='n_lost_particles.dat',status='unknown')
+            write(n_lost_unit,*) counter_lost_particles
+            close(n_lost_unit)
 !
 !------------------------------------------------------------------------------------------------------------!
 !-------------- Computation of transport diffusion coefficient by linear least squares fit ------------------!

--- a/SRC/fluxtv_mod.f90
+++ b/SRC/fluxtv_mod.f90
@@ -32,7 +32,7 @@
 !
       logical :: file_exist,boole_t_finished
       integer :: iface,i,j,k,l,m,n,ind_tetr,ind_tetr_save,iper,io_error
-      integer :: ind_tetr_temp,ipert
+      integer :: ind_tetr_temp,ipert,fluxtv_unit
       integer(kind=8) :: counter_mappings,counter_t_steps
       double precision :: phi_start, R_torus,R0,Z0,t_pass,t_remain, &
                           vmod,vpar,vperp,fluxtv_tetra,t_sum, &
@@ -141,26 +141,26 @@
 !
       inquire(file=filename_fluxtv_precomp ,exist = file_exist)
       if(file_exist) then
-        open(unit=20,file=filename_fluxtv_precomp,status='old',iostat=io_error)
-        if(io_error.eq.0) close(unit=20,status='delete')
+        open(newunit=fluxtv_unit,file=filename_fluxtv_precomp,status='old',iostat=io_error)
+        if(io_error.eq.0) close(unit=fluxtv_unit,status='delete')
       else
         !print *,'Error: Could not open and delete existing file'
         print *,'No existing file. Created new one to store data.'
       endif
-      open(unit=20,file=filename_fluxtv_precomp,status='new',action='write', &
+      open(newunit=fluxtv_unit,file=filename_fluxtv_precomp,status='new',action='write', &
       & iostat=io_error)
 !
       if ( io_error == 0) then
-        write(20,*) shape(pos_fluxtv_mat(:,1:4))
-        write(20,*) grid_configuration
+        write(fluxtv_unit,*) shape(pos_fluxtv_mat(:,1:4))
+        write(fluxtv_unit,*) grid_configuration
         do i = 1,nt_steps
-          write(20,*) pos_fluxtv_mat(i,1:4)
+          write(fluxtv_unit,*) pos_fluxtv_mat(i,1:4)
         enddo
       else
         write(*,*) 'Beim OEffenen der Datei ist ein Fehler Nr.', &
         io_error,' aufgetreten'
       end if
-      close(unit=20)
+      close(unit=fluxtv_unit)
 !
 !       !If symmetry flux coordinates are used, transform to cylindrical coordinates
 !       if(coord_system.eq.2) then
@@ -184,13 +184,13 @@
 !
         implicit none
 !
-        integer :: i
+        integer :: i, fluxtv_unit
 !
         if(.not.(allocated(pos_fluxtv_mat))) then
             !Read the coordinates data
-            open(unit = 22, file=filename_fluxtv_load, status='old',action = 'read')
-            read(22,*) pos_fluxtv_mat_shape(1),pos_fluxtv_mat_shape(2)
-            read(22,*) grid_configuration
+            open(newunit = fluxtv_unit, file=filename_fluxtv_load, status='old',action = 'read')
+            read(fluxtv_unit,*) pos_fluxtv_mat_shape(1),pos_fluxtv_mat_shape(2)
+            read(fluxtv_unit,*) grid_configuration
 !
             !Check, if Fluxtube volume was correctly computed before diffusion coefficent computation
             if(any(grid_configuration.ne.[grid_kind,coord_system,grid_size(1),grid_size(2),grid_size(3)])) then
@@ -202,9 +202,9 @@
 !
             allocate(pos_fluxtv_mat(1:pos_fluxtv_mat_shape(1),1:pos_fluxtv_mat_shape(2)))
             do i=1,pos_fluxtv_mat_shape(1)
-                read(22,*) pos_fluxtv_mat(i,1:pos_fluxtv_mat_shape(2))
+                read(fluxtv_unit,*) pos_fluxtv_mat(i,1:pos_fluxtv_mat_shape(2))
             enddo
-            close(unit = 22)
+            close(unit = fluxtv_unit)
         endif
 !
     end subroutine load_flux_tube_volume

--- a/SRC/gorilla_applets_settings_mod.f90
+++ b/SRC/gorilla_applets_settings_mod.f90
@@ -23,9 +23,11 @@
 !            
         subroutine load_gorilla_applets_inp()
 !
-            open(unit=11, file='gorilla_applets.inp', status='unknown')
-            read(11,nml=GORILLA_APPLETS_NML)
-            close(11)
+            integer :: inp_unit
+!
+            open(newunit=inp_unit, file='gorilla_applets.inp', status='unknown')
+            read(inp_unit,nml=GORILLA_APPLETS_NML)
+            close(inp_unit)
 
             print *,'GORILLA_APPLETS: Loaded input data from input file'
 !            

--- a/SRC/gorilla_applets_sub_mod.f90
+++ b/SRC/gorilla_applets_sub_mod.f90
@@ -108,24 +108,19 @@
 !
             !Initialize GORILLA with electrostatic potential in accordance with Mach number for mono-energetic transport coefficient
             call initialize_mono_energetic_transp_coef()
-
-            !File ids for squared deviaton, standard deviation and diffusion coefficient
-            file_id_psi2 = 14
-            file_id_std_psi2 = 15
-            file_id_transp_diff_coef = 16
 !
             !nu_star = [(2.d0**i, i=nu_start,(nu_start-(n_nu_scans+1)), -1)] ! nu_star = \frac{R_0 \nu_c}{\iota v_{mod}}
 !
             select case(idiffcoef_output)
                 case(1)
-                    open(file_id_transp_diff_coef,file=filename_transp_diff_coef)
+                    open(newunit=file_id_transp_diff_coef,file=filename_transp_diff_coef)
                 case(2)
-                    open(file_id_psi2,file=filename_delta_s_squared)
-                    open(file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
+                    open(newunit=file_id_psi2,file=filename_delta_s_squared)
+                    open(newunit=file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
                 case(3)
-                    open(file_id_transp_diff_coef,file=filename_transp_diff_coef)
-                    open(file_id_psi2,file=filename_delta_s_squared)
-                    open(file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
+                    open(newunit=file_id_transp_diff_coef,file=filename_transp_diff_coef)
+                    open(newunit=file_id_psi2,file=filename_delta_s_squared)
+                    open(newunit=file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
             end select
 !
             print *, 'Mono-energetic radial transport coefficient:'
@@ -198,22 +193,17 @@
 !
             !Initialize GORILLA with electrostatic potential in accordance with Mach number for mono-energetic transport coefficient
             call initialize_mono_energetic_transp_coef()
-
-            !File ids for squared deviaton, standard deviation and diffusion coefficient
-            file_id_psi2 = 14
-            file_id_std_psi2 = 15
-            file_id_transp_diff_coef = 16
 !
             select case(idiffcoef_output)
                 case(1)
-                    open(file_id_transp_diff_coef,file=filename_transp_diff_coef)
+                    open(newunit=file_id_transp_diff_coef,file=filename_transp_diff_coef)
                 case(2)
-                    open(file_id_psi2,file=filename_delta_s_squared)
-                    open(file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
+                    open(newunit=file_id_psi2,file=filename_delta_s_squared)
+                    open(newunit=file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
                 case(3)
-                    open(file_id_transp_diff_coef,file=filename_transp_diff_coef)
-                    open(file_id_psi2,file=filename_delta_s_squared)
-                    open(file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
+                    open(newunit=file_id_transp_diff_coef,file=filename_transp_diff_coef)
+                    open(newunit=file_id_psi2,file=filename_delta_s_squared)
+                    open(newunit=file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
             end select
 !
             print *, 'Mono-energetic radial transport coefficient - Scan over normalized collisionality:'
@@ -308,25 +298,20 @@
             !Compute velocity module from kinetic energy dependent on particle species
             vmod=sqrt(2.d0*energy_eV*ev2erg/particle_mass)
 !
-            !file id for squared deviaton
-            file_id_psi2 = 14
-            file_id_std_psi2 = 15
-            file_id_transp_diff_coef = 16
-!
             print *, 'Numerical radial transport diffusion coefficient:'
             print *, ''
             print *, 'Number of particles', n_particles
 !
             select case(idiffcoef_output)
                 case(1)
-                    open(file_id_transp_diff_coef,file=filename_numerical_diff_coef)
+                    open(newunit=file_id_transp_diff_coef,file=filename_numerical_diff_coef)
                 case(2)
-                    open(file_id_psi2,file=filename_delta_s_squared)
-                    open(file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
+                    open(newunit=file_id_psi2,file=filename_delta_s_squared)
+                    open(newunit=file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
                 case(3)
-                    open(file_id_transp_diff_coef,file=filename_numerical_diff_coef)
-                    open(file_id_psi2,file=filename_delta_s_squared)
-                    open(file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
+                    open(newunit=file_id_transp_diff_coef,file=filename_numerical_diff_coef)
+                    open(newunit=file_id_psi2,file=filename_delta_s_squared)
+                    open(newunit=file_id_std_psi2,file=filename_std_dvt_delta_s_squared)
             end select
 !
             !Define step size

--- a/SRC/mono_energetic_transp_coef_settings_mod.f90
+++ b/SRC/mono_energetic_transp_coef_settings_mod.f90
@@ -42,9 +42,11 @@
 !            
         subroutine load_mono_energetic_transp_coef_inp()
 !
-            open(unit=11, file='mono_energetic_transp_coef.inp', status='unknown')
-            read(11,nml=TRANSPCOEFNML)
-            close(11)
+            integer :: inp_unit
+!
+            open(newunit=inp_unit, file='mono_energetic_transp_coef.inp', status='unknown')
+            read(inp_unit,nml=TRANSPCOEFNML)
+            close(inp_unit)
 
             print *,'Mono-energetic transport coefficient: Loaded input data from input file'
 !            

--- a/SRC/poincare_invariances_mod.f90
+++ b/SRC/poincare_invariances_mod.f90
@@ -22,7 +22,7 @@ module poincare_invariances_mod
         implicit none
 !
         integer :: n_orbits, i,j,k,l, i_integrator_type, n_steps, counter_particles, file_id_orbit_position,n_orbit_positions
-        integer :: delta_orbit_position, file_id_orbit_cyl
+        integer :: delta_orbit_position, file_id_orbit_cyl, pi_unit
         double precision :: s_0, theta_0, phi_0, pitchpar_0
         double precision, dimension(:), allocatable :: alpha_0_vec
         double precision :: J_perp, t_total, vmod, bmod, delta_theta, delta_phi,perpinv,perpinv2
@@ -74,9 +74,9 @@ print *, ''
 !
         select case(i_integrator_type)
             case(1)
-                open(2,file='results/poincare_invariance_gorilla_n_1E7_e_var_jperp_var_dtdtau_ham_O4.dat')
+                open(newunit=pi_unit,file='results/poincare_invariance_gorilla_n_1E7_e_var_jperp_var_dtdtau_ham_O4.dat')
             case(2)
-                open(2,file='results/poincare_invariance_direct_1E-08_ns_s3.dat')
+                open(newunit=pi_unit,file='results/poincare_invariance_direct_1E-08_ns_s3.dat')
         end select
 !
         !File ID for orbit position
@@ -349,10 +349,10 @@ print *, ''
 !
         !Write first Poincaré invariance
         do j = 1,n_steps+1
-            write(2,*) j,first_poincare_invariance(j),gyro_term(j)
+            write(pi_unit,*) j,first_poincare_invariance(j),gyro_term(j)
         enddo
 !
-        close(2)
+        close(pi_unit)
 !
 !
 !

--- a/SRC/reversibility_test_mod.f90
+++ b/SRC/reversibility_test_mod.f90
@@ -52,9 +52,11 @@ module reversibility_test_load_mod
 
     subroutine load_reversibility_test_inp()
 !
-            open(unit=10, file='reversibility_test.inp', status='unknown')
-            read(10,nml=reversibility_test_nml)
-            close(10)
+            integer :: inp_unit
+!
+            open(newunit=inp_unit, file='reversibility_test.inp', status='unknown')
+            read(inp_unit,nml=reversibility_test_nml)
+            close(inp_unit)
 !
     end subroutine load_reversibility_test_inp
 
@@ -259,8 +261,7 @@ module reversibility_test_mod
 
         delta_snapshot = n_steps/n_snapshots
         !File ID for orbit position
-        file_id_reversibility_test = 100
-        open(file_id_reversibility_test,file=filename_reversibility_test)
+        open(newunit=file_id_reversibility_test,file=filename_reversibility_test)
         !Write orbit positions
         do l = 1, n_snapshots
             j = 1 + (l-1)*delta_snapshot
@@ -282,8 +283,7 @@ module reversibility_test_mod
         close(file_id_reversibility_test)
 !
         !File ID for orbit position backwards
-        file_id_reversibility_test_back = 200
-        open(file_id_reversibility_test_back,file=filename_reversibility_test_back)
+        open(newunit=file_id_reversibility_test_back,file=filename_reversibility_test_back)
         !Write orbit positions
         do l = 1, n_snapshots
             !We save the backwards integrated quantities in reversed order to be comparable to forward integrated ones
@@ -630,7 +630,7 @@ if(boole_diag_reversibility_test) stop
         double precision, dimension(:), allocatable         :: rand_noise_vec
         integer, dimension(:), allocatable                   :: seed
         double precision, dimension(:), allocatable         :: rd_seed
-        integer                                             :: n
+        integer                                             :: n, seed_unit
 !
         allocate(rand_noise_vec(n_orbits+1),get_rand_noise_vec(n_orbits+1))
 !
@@ -644,16 +644,16 @@ if(boole_diag_reversibility_test) stop
                 call random_number(rd_seed)
                 seed = int(rd_seed*10.d0)
                 deallocate(rd_seed)
-                open(85,file='seed.inp')
-                write(85,*) n
-                write(85,*) seed
-                close(85)
+                open(newunit=seed_unit,file='seed.inp')
+                write(seed_unit,*) n
+                write(seed_unit,*) seed
+                close(seed_unit)
             case(2) !Load seed
-                open(unit = 85, file='seed.inp', status='old',action = 'read')
-                read(85,*) n
+                open(newunit = seed_unit, file='seed.inp', status='old',action = 'read')
+                read(seed_unit,*) n
                 allocate(seed(n))
-                read(85,*) seed
-                close(85)
+                read(seed_unit,*) seed
+                close(seed_unit)
         end select
 !
         CALL RANDOM_SEED (PUT=seed)

--- a/SRC/utils_self_consistent_ef_mod.f90
+++ b/SRC/utils_self_consistent_ef_mod.f90
@@ -1315,9 +1315,7 @@ subroutine calc_electron_diffusion_coefficients !call this before the first ion 
         !         write(23,*) start%energy(i,2)
         !     enddo
         ! close(23)
-        open(71)
         call parallelised_particle_pushing(species = 2,j = 1,boole_diffusion_coefficient = .true.,n_particles_in=s%n_particles)
-        close(71)
 
 
 
@@ -1400,11 +1398,11 @@ subroutine calc_electron_diffusion_coefficients !call this before the first ion 
         dc%grad_B(ns) = (dc%B(ns+1)-dc%B(ns))/(dc%s_vertices(ns+1)-dc%s_vertices(ns))
     enddo
 
-    open(23,file = 'A_and_B.dat')
+    open(newunit=file_id,file = 'A_and_B.dat')
     do i = 1,grid_size(1)+1
-        write(23,*) dc%A(i), dc%B(i)
+        write(file_id,*) dc%A(i), dc%B(i)
     enddo
-    close(23)
+    close(file_id)
 
 end subroutine calc_electron_diffusion_coefficients
 
@@ -1417,6 +1415,7 @@ subroutine calc_electron_density_via_random_walk(iteration_step) !call this afte
 
     real(dp) :: delta_x, delta_t, xi, A, B, cell_size, B_fit, A_fit, p
     integer :: i, ns, k, num_steps_min, count_lost_particles, num_particles, particle_multiplication, iteration_step
+    integer :: density_unit
     real(dp), dimension(:), allocatable :: electron_density, electron_prism_densities
     real(dp), dimension(:), allocatable :: position, weight, exit_time
     type(time_t) :: t
@@ -1516,11 +1515,11 @@ count_lost_particles = 0
                                                         count_lost_particles,'out of', num_particles, &
                                                         'electrons left the computation domain'
 
-    open(10)
+    open(newunit=density_unit,file='electron_density.dat')
     do ns = 1, grid_size(1)
-        write(10,*) sfc_s_min + (1.0_dp - sfc_s_min) * (ns - 0.5_dp) / (grid_size(1)+1), electron_density(ns)
+        write(density_unit,*) sfc_s_min + (1.0_dp - sfc_s_min) * (ns - 0.5_dp) / (grid_size(1)+1), electron_density(ns)
     enddo
-    close(10)
+    close(density_unit)
 
     do i = 1,grid_size(1)
         electron_density(i) = electron_density(i)/(ep%s_shell_volumes(i)*t%step*num_particles)


### PR DESCRIPTION
Replaces hardcoded Fortran unit numbers in open() statements with newunit= across SRC/, eliminating the risk of unit clashes between modules. Drops the inactive open(71)/close(71) debug bracket around parallelised_particle_pushing since reinstating its commented-out write would require passing the unit through the call signature.

Fixes #4.