### PR TITLE
Refactor field_line_tracing and add CI test

### DIFF
--- a/EXAMPLES/field_line_tracing/field_line_tracing.inp
+++ b/EXAMPLES/field_line_tracing/field_line_tracing.inp
@@ -29,15 +29,6 @@
   !Start all particles from the same physical position
   boole_point_source = .false.,
 !
-  !include a collision operator
-  boole_collisions = .false.,
-!
-  !precalcualte random numbers for collisions
-  boole_precalc_collisions = .false.,
-!
-  !Simulated density of particles
-  density = 1,
-!
   !refined jacobian determinant
   boole_refined_sqrt_g = .true.,
 !

--- a/INPUT/field_line_tracing.inp
+++ b/INPUT/field_line_tracing.inp
@@ -29,15 +29,6 @@
   !Start all particles from the same physical position
   boole_point_source = .false.,
 !
-  !include a collision operator
-  boole_collisions = .false.,
-!
-  !precalcualte random numbers for collisions
-  boole_precalc_collisions = .false.,
-!
-  !Simulated density of particles
-  density = 1,
-!
   !refined jacobian determinant
   boole_refined_sqrt_g = .true.,
 !

--- a/SRC/field_line_tracing_mod.f90
+++ b/SRC/field_line_tracing_mod.f90
@@ -10,14 +10,12 @@ module field_line_tracing_mod
     double precision, dimension(:,:), allocatable :: verts
     integer :: seed_option, num_particles,&
                & ind_a, ind_b, ind_c
-    double precision :: n_particles, density, constant_part_of_weights, z_div_plate
+    double precision :: n_particles, constant_part_of_weights, z_div_plate
     double complex, dimension(:,:), allocatable :: weights
     double precision, dimension(:), allocatable :: J_perp, poloidal_flux, temperature_vector
     logical :: boole_linear_density_simulation, boole_linear_temperature_simulation, &
-             & boole_poincare_plot, boole_divertor_intersection, boole_collisions, boole_point_source, boole_precalc_collisions, &
+             & boole_poincare_plot, boole_divertor_intersection, boole_point_source, &
              & boole_refined_sqrt_g, boole_monoenergetic
-    double precision, dimension(:,:,:), allocatable :: randcol
-    integer :: randcoli = int(1.0d5)
     integer :: n_poincare_mappings, n_mappings_ignored
     integer :: pm_unit, di_unit !file units
     type counter_t
@@ -32,8 +30,8 @@ module field_line_tracing_mod
 
     !Namelist for field_line_tracing input
     NAMELIST /field_line_tracing_nml/ time_step,energy_eV,n_particles,boole_poincare_plot,n_poincare_mappings,n_mappings_ignored, &
-    & boole_divertor_intersection, z_div_plate,boole_point_source,boole_collisions, &
-    & boole_precalc_collisions,density,boole_refined_sqrt_g,boole_monoenergetic, boole_linear_density_simulation, &
+    & boole_divertor_intersection, z_div_plate,boole_point_source, &
+    & boole_refined_sqrt_g,boole_monoenergetic, boole_linear_density_simulation, &
     & boole_linear_temperature_simulation,seed_option
 
     public :: calc_field_lines
@@ -43,7 +41,7 @@ contains
 subroutine calc_field_lines
 
     use orbit_timestep_gorilla_mod, only: initialize_gorilla
-    use constants, only: ev2erg,pi,echarge,ame,amp,clight
+    use constants, only: ev2erg,pi,echarge
     use tetra_physics_mod, only: particle_mass,particle_charge,cm_over_e,mag_axis_R0, coord_system, tetra_physics
     use omp_lib, only: omp_get_thread_num, omp_get_num_threads, omp_set_num_threads
     use parmot_mod, only: rmu,ro0
@@ -52,26 +50,20 @@ subroutine calc_field_lines
     use tetra_grid_settings_mod, only: n_field_periods, grid_size
     use tetra_grid_mod, only: ntetr, nvert, verts_rphiz, tetra_grid, verts_sthetaphi
     use gorilla_settings_mod, only: ispecies
-    use collis_ions, only: collis_init, stost
     use find_tetra_mod, only: find_tetra
     use gorilla_applets_settings_mod, only: i_option
     use field_mod, only: ipert
     use volume_integrals_and_sqrt_g_mod, only: calc_square_root_g
     use utils_data_pre_and_post_processing_mod, only: get_ipert
 
-    double precision, dimension(:,:), allocatable :: start_pos_pitch_mat, dens_mat, temp_mat, vpar_mat, efcolf_mat, &
-                                                     velrat_mat, enrat_mat, dens_mat_tetr, temp_mat_tetr
-    double precision :: v0,pitchpar,vpar,vperp,t_remain,t_confined, v, maxcol
-    integer :: kpart,i,j,n,m,k,ind_tetr,iface,ierr,err,num_background_species
-    integer :: n_start, n_end, i_part
-    double precision, dimension(3) :: x_rand_beg,x,randnum
+    double precision, dimension(:,:), allocatable :: start_pos_pitch_mat
+    double precision :: v0,pitchpar,vpar,vperp,t_remain,t_confined, v
+    integer :: kpart,i,n,ind_tetr,iface,ierr
+    integer :: n_start, n_end
+    double precision, dimension(3) :: x_rand_beg,x
     logical :: boole_initialized,boole_particle_lost
-    double precision :: dtau, dphi,dtaumin, t_step
-    double precision, dimension(5) :: z, zet
-    double precision :: m0,z0
-    double precision, dimension(:), allocatable :: efcolf,velrat,enrat,vpar_background,mass,charge_num,dens,temp
+    double precision :: t_step
     type(counter_t) :: counter, local_counter
-    integer :: Te_unit, Ti_unit, ne_unit
 
     !Load input for boltzmann computation
     call read_field_line_tracing_inp()
@@ -116,97 +108,22 @@ print*, 'calc_starting_conditions finished'
         min_poloidal_flux = min(min_poloidal_flux,tetra_physics(i)%Aphi1)
     enddo
 
-    !write subroutine collis_precomp
-    if (boole_collisions) then
-        num_background_species = 2
-        allocate(dens_mat(num_background_species,size(verts_rphiz(1,:))))
-        allocate(temp_mat(num_background_species,size(verts_rphiz(1,:))))
-        allocate(vpar_mat(num_background_species,ntetr))
-        allocate(efcolf_mat(num_background_species,ntetr))
-        allocate(velrat_mat(num_background_species,ntetr))
-        allocate(enrat_mat(num_background_species,ntetr))
-        allocate(mass(num_background_species))
-        allocate(charge_num(num_background_species))
-        allocate(dens(num_background_species))
-        allocate(temp(num_background_species))
-        allocate(efcolf(num_background_species))
-        allocate(velrat(num_background_species))
-        allocate(enrat(num_background_species))
-        mass = 0
-        charge_num = 0.0d0
-        mass(1) = 2*amp
-        !mass(2) = 3*amp
-        mass(num_background_species) = ame
-        charge_num(1) = 1.0d0
-        !charge_num(2) = 2
-        charge_num(num_background_species) = -1.0d0
-        dens_mat = 5.0d13
-        temp_mat = energy_eV
-        vpar_mat = 0
-        m0 = particle_mass
-        z0 = particle_charge/echarge
-        print*, 'm0 = ', m0, 'z0 = ', z0
-
-!!!!!!!!!!!!!!!!!!!! Alternative route is taken because data is not available per vertex but per tetrahedron !!!!!!!!!!!!!!!!!!!!!!!
-
-        allocate(dens_mat_tetr(num_background_species,ntetr))
-        allocate(temp_mat_tetr(num_background_species,ntetr))
-
-        open(newunit = Te_unit, file = 'background/Te_d.dat')
-        read(Te_unit,'(e16.9)') (temp_mat_tetr(2,i),i=1,ntetr/grid_size(2),3)
-        close(Te_unit)
-
-        open(newunit = Ti_unit, file = 'background/Ti_d.dat')
-        read(Ti_unit,'(e16.9)') (temp_mat_tetr(1,i),i=1,ntetr/grid_size(2),3)
-        close(Ti_unit)
-
-        open(newunit = ne_unit, file = 'background/ne_d.dat')
-        read(ne_unit,'(e16.9)') (dens_mat_tetr(1,i),i=1,ntetr/grid_size(2),3)
-        dens_mat_tetr(2,:) = dens_mat_tetr(1,:)
-        close(ne_unit)
-
-        do i = 1,grid_size(2)-1
-            temp_mat_tetr(:,i*ntetr/grid_size(2)+1:(i+1)*ntetr/grid_size(2):3) = temp_mat_tetr(:,1:ntetr/grid_size(2):3)
-            dens_mat_tetr(:,i*ntetr/grid_size(2)+1:(i+1)*ntetr/grid_size(2):3) = dens_mat_tetr(:,1:ntetr/grid_size(2):3)
-        enddo
-        do i = 1,2
-            temp_mat_tetr(:,1+i:ntetr:3) = temp_mat_tetr(:,1:ntetr:3)
-            dens_mat_tetr(:,1+i:ntetr:3) = dens_mat_tetr(:,1:ntetr:3)
-        enddo
-
-        do i = 1, ntetr
-            do j = 1,num_background_species
-                dens(j) = sum(dens_mat_tetr(j,tetra_grid(i)%ind_knot([1,2,3,4])))/4
-                temp(j) = sum(temp_mat_tetr(j,tetra_grid(i)%ind_knot([1,2,3,4])))/4
-            enddo
-            call collis_init(m0,z0,mass,charge_num,dens,temp,energy_eV,v0,efcolf,velrat,enrat)
-            efcolf_mat(:,i) = efcolf
-            velrat_mat(:,i) = velrat
-            enrat_mat(:,i) = enrat
-        enddo
-    endif
-
         kpart = 0
-        maxcol = 0
 
         call unlink_files
         call open_files
 
-        if (boole_collisions) deallocate(efcolf,velrat,enrat)
-
         !$OMP PARALLEL DEFAULT(NONE) &
-        !$OMP& SHARED(num_particles,kpart,v0,time_step,boole_collisions, &
-        !$OMP& dtau,dtaumin,n_start,n_end, &
+        !$OMP& SHARED(num_particles,kpart,v0,time_step, &
+        !$OMP& n_start,n_end, &
         !$OMP& start_pos_pitch_mat,boole_monoenergetic, &
-        !$OMP& density,energy_eV,dens_mat,temp_mat,vpar_mat,tetra_grid,tetra_physics, &
-        !$OMP& efcolf_mat,velrat_mat,enrat_mat,num_background_species,randcol,randcoli,maxcol,boole_precalc_collisions, counter) &
+        !$OMP& energy_eV,tetra_grid,tetra_physics, counter) &
         !$OMP& FIRSTPRIVATE(particle_mass, particle_charge) &
-        !$OMP& PRIVATE(n,boole_particle_lost,x_rand_beg,x,pitchpar,vpar,vperp,boole_initialized,t_step,err,zet, &
-        !$OMP& ind_tetr,iface,t_remain,t_confined,z,ierr,v, &
-        !$OMP& i,efcolf,velrat,enrat,vpar_background,randnum,j,local_counter)
+        !$OMP& PRIVATE(n,boole_particle_lost,x_rand_beg,x,pitchpar,vpar,vperp,boole_initialized,t_step, &
+        !$OMP& ind_tetr,iface,t_remain,t_confined,ierr,v, &
+        !$OMP& i,local_counter)
 
         print*, 'get number of threads', omp_get_num_threads()
-        if (boole_collisions) allocate(efcolf(num_background_species),velrat(num_background_species),enrat(num_background_species))
         !$OMP DO
 
         !Loop over particles
@@ -252,40 +169,6 @@ endif
                     boole_initialized = .false.
                 endif
 
-                if (boole_collisions) then
-                    if (i.eq.1) call find_tetra(x,vpar,vperp,ind_tetr,iface)
-                    if (.not.(ind_tetr.eq.-1)) then
-                        efcolf = efcolf_mat(:,ind_tetr)
-                        velrat = velrat_mat(:,ind_tetr)
-                        enrat = enrat_mat(:,ind_tetr)
-                        vpar_background = vpar_mat(:,ind_tetr)
-                        !print*, vpar_background
-                        vpar = vpar - vpar_background(1)
-                        !since vpar_background actually has num_background_particles entries, consider giving it as an extra
-                        !optional input variable to stost, before randnum (maybe also check if radnum could then be set by
-                        !randnum = variable eve if vpar_background is not set and other variables are not set by name indexing)
-                        !since it came up when writing these lines: replace expressions like
-                        !"verts(size(verts_rphiz(:,1)),size(verts_rphiz(1,:)))" with "3,nvert"
-                        zet(1:3) = x !spatial position
-                        zet(4) = sqrt(vpar**2+vperp**2)/v0 !normalized velocity module
-                        zet(5) = vpar/sqrt(vpar**2+vperp**2) !pitch parameter
-                        if (boole_precalc_collisions) then
-                            randnum = randcol(n,mod(i-1,randcoli)+1,:)
-                            call stost(efcolf,velrat,enrat,zet,t_step,1,err,(time_step-t_confined)*v0,randnum)
-                        else
-                            call stost(efcolf,velrat,enrat,zet,t_step,1,err,(time_step-t_confined)*v0)
-                        endif
-                        t_step = t_step/v0
-                        x = zet(1:3)
-                        vpar = zet(5)*zet(4)*v0+vpar_background(1)
-                        vperp = sqrt(1-zet(5)**2)*zet(4)*v0
-                        !optionally still change particle_mass, particle_charge and cm_over_e, e.g.:
-                        !particle_charge = particle_charge + echarge
-                        !particle_mass = particle_mass + ame - amp
-                        !cm_over_e = clight*particle_mass/particle_charge
-                    endif
-                endif
-
                 call orbit_timestep_gorilla_field_lines(x,vpar,vperp,t_step,boole_initialized,ind_tetr,iface, &
                                 & n,v,start_pos_pitch_mat,local_counter,t_remain)
 
@@ -306,7 +189,6 @@ endif
             enddo
             !$omp critical
             counter%integration_steps = counter%integration_steps + i
-            maxcol = max(dble(i)/dble(randcoli),maxcol)
             call add_local_counter_to_counter(local_counter,counter)
             !$omp end critical
         enddo !n
@@ -315,7 +197,6 @@ endif
 
         call close_files
 
-if (boole_precalc_collisions) print*, "maxcol = ", maxcol
 print*, 'average number of pushings = ', counter%tetr_pushings/n_particles
 print*, 'average number of toroidal revolutions = ', counter%phi_0_mappings/n_particles
 if (boole_divertor_intersection) then
@@ -633,7 +514,7 @@ subroutine calc_starting_conditions(v0,start_pos_pitch_mat)
     cmin = minval(verts(ind_c,:))
     cmax = maxval(verts(ind_c,:))
 
-    constant_part_of_weights = density*(amax-amin)*(cmax-cmin)*2*pi
+    constant_part_of_weights = (amax-amin)*(cmax-cmin)*2*pi
 
     !compute starting conditions
     if (boole_point_source) then
@@ -664,12 +545,6 @@ subroutine calc_starting_conditions(v0,start_pos_pitch_mat)
     weights(:,1) = constant_part_of_weights
     if (boole_refined_sqrt_g.eqv..false.) weights(:,1) = constant_part_of_weights*start_pos_pitch_mat(ind_a,:)
 
-    if (boole_precalc_collisions) then
-        allocate(randcol(num_particles,randcoli,3))
-        call RANDOM_NUMBER(randcol)
-        !3.464102 = sqrt(12), this creates a random number with zero average and unit variance
-        randcol(:,:,1:3:2) =  3.464102*(randcol(:,:,1:3:2)-.5)
-    endif
 end subroutine calc_starting_conditions
 
 end module field_line_tracing_mod

--- a/SRC/field_line_tracing_mod.f90
+++ b/SRC/field_line_tracing_mod.f90
@@ -57,6 +57,7 @@ subroutine calc_field_lines
     use gorilla_applets_settings_mod, only: i_option
     use field_mod, only: ipert
     use volume_integrals_and_sqrt_g_mod, only: calc_square_root_g
+    use utils_data_pre_and_post_processing_mod, only: get_ipert
 
     double precision, dimension(:,:), allocatable :: start_pos_pitch_mat, dens_mat, temp_mat, vpar_mat, efcolf_mat, &
                                                      velrat_mat, enrat_mat, dens_mat_tetr, temp_mat_tetr
@@ -70,7 +71,7 @@ subroutine calc_field_lines
     double precision :: m0,z0
     double precision, dimension(:), allocatable :: efcolf,velrat,enrat,vpar_background,mass,charge_num,dens,temp
     type(counter_t) :: counter, local_counter
-    integer :: ipert_unit, Te_unit, Ti_unit, ne_unit
+    integer :: Te_unit, Ti_unit, ne_unit
 
     !Load input for boltzmann computation
     call read_field_line_tracing_inp()
@@ -79,10 +80,7 @@ subroutine calc_field_lines
     n_start = 1
     n_end = num_particles
 
-
-    open(newunit = ipert_unit, file='field_divB0.inp')
-    read(ipert_unit,*) ipert        ! 0=eq only, 1=vac, 2=vac+plas no derivatives,
-    close(ipert_unit)
+    call get_ipert()
 
     !Initialize GORILLA
     call initialize_gorilla(i_option,ipert)
@@ -528,27 +526,6 @@ subroutine calc_plane_intersection(x_save,x,z_plane)
 
 end subroutine calc_plane_intersection
 
-subroutine cyl_to_cart(xcyl,xcart)
-
-    double precision, dimension(3), intent(in) :: xcyl
-    double precision, dimension(3), intent(out) :: xcart
-
-    xcart(1) = xcyl(1)*cos(xcyl(2))
-    xcart(2) = xcyl(1)*sin(xcyl(2))
-    xcart(3) = xcyl(3)
-
-end subroutine cyl_to_cart
-
-subroutine cart_to_cyl(xcart,xcyl)
-
-    double precision, dimension(3), intent(in) :: xcart
-    double precision, dimension(3), intent(out) :: xcyl
-
-    xcyl(1) = hypot(xcart(1),xcart(2))
-    xcyl(2) = atan2(xcart(2),xcart(1))
-    xcyl(3) = xcart(3)
-end subroutine cart_to_cyl
-
 subroutine set_counters_zero(local_counter)
 
     type(counter_t), intent(inout) :: local_counter
@@ -616,6 +593,7 @@ subroutine calc_starting_conditions(v0,start_pos_pitch_mat)
     use find_tetra_mod, only: find_tetra
     use tetra_grid_settings_mod, only: grid_kind
     use tetra_physics_mod, only: coord_system
+    use utils_data_pre_and_post_processing_mod, only: set_seed_for_random_numbers
 
     double precision, intent(in)                                   :: v0
     double precision, dimension(:,:), allocatable, intent(out)     :: start_pos_pitch_mat
@@ -625,20 +603,10 @@ subroutine calc_starting_conditions(v0,start_pos_pitch_mat)
     double precision, dimension(:), allocatable                    :: rand_matrix2
     integer                                                        :: i
     double precision, dimension(3)                                 :: x
-    integer                                                        :: ind_tetr_out,iface, seed_inp_unit
+    integer                                                        :: ind_tetr_out,iface
 
-!!!!comment out the following section to make starting conditions really random!!!
-
-    integer,dimension(:), allocatable                              :: seed
-    integer                                                        :: n
-
-    open(newunit = seed_inp_unit, file='seed.inp', status='old',action = 'read')
-    read(seed_inp_unit,*) n
-    allocate(seed(n))
-    read(seed_inp_unit,*) seed
-    close(seed_inp_unit)
-    CALL RANDOM_SEED (PUT=seed)
-    deallocate(seed)
+!!!!comment out the following call to make starting conditions really random!!!
+    call set_seed_for_random_numbers
 
     allocate(start_pos_pitch_mat(5,num_particles))
     allocate(rand_vector(num_particles))

--- a/SRC/pusher_tetra_field_lines_mod.f90
+++ b/SRC/pusher_tetra_field_lines_mod.f90
@@ -20,36 +20,33 @@ module pusher_tetra_field_lines_mod
     integer                             :: iface_init
     integer, public, protected          :: ind_tetr
     integer, public, protected          :: sign_rhs
-    double precision                    :: vmod0
-    double precision, public, protected :: perpinv,dt_dtau_const,bmod0
+    double precision, public, protected :: dt_dtau_const
     double precision                    :: t_remain
     double precision, dimension(3)      :: x_init
     double precision, dimension(4), public, protected :: z_init
-    double precision                    :: k1, k3
 !
-    !$OMP THREADPRIVATE(ind_tetr,iface_init,perpinv,dt_dtau_const,bmod0,t_remain,x_init,  &
-    !$OMP& z_init,k1,k3,vmod0,sign_rhs)
-! 
+    !$OMP THREADPRIVATE(ind_tetr,iface_init,dt_dtau_const,t_remain,x_init,  &
+    !$OMP& z_init,sign_rhs)
+!
     public :: pusher_tetra_field_lines,analytic_integration
 !  
     contains
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
-        subroutine initialize_pusher_tetra_poly(ind_tetr_inout,x,iface,vpar,t_remain_in)
+        subroutine initialize_pusher_tetra_field_lines(ind_tetr_inout,x,iface,vpar,t_remain_in)
 !
             use tetra_physics_mod, only: tetra_physics, sign_sqg
-            use supporting_functions_mod, only: bmod_func, phi_elec_func, v2_E_mod_func
 !
             implicit none
 !
             integer, intent(in)                        :: ind_tetr_inout,iface
             double precision, intent(in)               :: vpar
             double precision, dimension(3), intent(in) :: x
-            double precision                           :: vperp2,vpar2,t_remain_in,phi_elec
+            double precision, intent(in)               :: t_remain_in
 !
             t_remain = t_remain_in
-!    
+!
             ind_tetr=ind_tetr_inout           !Save the index of the tetrahedron locally
 !
             !Sign of the right hand side of ODE - ensures that tau is ALWAYS positive inside the algorithm
@@ -70,32 +67,17 @@ module pusher_tetra_field_lines_mod
 !
             !Multiply with sign of rhs - ensures that tau is ALWAYS positive inside the algorithm
             dt_dtau_const = dt_dtau_const*dble(sign_rhs)
-!    
-            !Module of B at the entry point of the particle
-            bmod0 = bmod_func(z_init(1:3),ind_tetr) !tetra_physics(ind_tetr)%bmod1+sum(tetra_physics(ind_tetr)%gb*z_init(1:3))
 !
-            !Phi at the entry point of the particle
-            phi_elec = phi_elec_func(z_init(1:3),ind_tetr)   !tetra_physics(ind_tetr)%Phi1+sum(tetra_physics(ind_tetr)%gPhi*z_init(1:3))
-!
-            !Auxiliary quantities (unused by the field-line pusher itself, kept for diagnostics)
-            vperp2 = -2.d0*perpinv*bmod0
-            vpar2 = vpar**2
-            vmod0 = sqrt(vpar2+vperp2)
-!
-            k1 = vperp2+vpar2+2.d0*perpinv*tetra_physics(ind_tetr)%bmod1
-            k3 = tetra_physics(ind_tetr)%Phi1-phi_elec
-!
-        end subroutine initialize_pusher_tetra_poly
+        end subroutine initialize_pusher_tetra_field_lines
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
         subroutine pusher_tetra_field_lines(ind_tetr_inout,iface,x,vpar,z_save,t_remain_in,t_pass, &
                         & boole_t_finished,iper_phi)
 !
-            use tetra_physics_mod, only: tetra_physics,particle_charge,particle_mass
+            use tetra_physics_mod, only: tetra_physics
             use gorilla_diag_mod,  only: diag_pusher_tetry_poly
             use pusher_tetra_func_mod, only: pusher_handover2neighbour
-            use gorilla_settings_mod, only: boole_guess, boole_adaptive_time_steps
 !
             implicit none
 !
@@ -111,15 +93,13 @@ module pusher_tetra_field_lines_mod
             integer,intent(out)                                   :: iper_phi
 !
             logical, dimension(4)                                 :: boole_faces
-            integer                                               :: i,j,k
-            double precision, dimension(4)                        :: z,z_dummy
+            integer                                               :: i
+            double precision, dimension(4)                        :: z
             integer                                               :: iface_new
-            double precision                                      :: tau,vperp2,tau_save,tau_max, energy_init,energy_current
+            double precision                                      :: tau
             logical                                               :: boole_analytical_approx,boole_face_correct
-            integer                                               :: i_step_root
-            double precision                                      :: t_remain_new
 !
-            call initialize_pusher_tetra_poly(ind_tetr_inout,x,iface,vpar,t_remain_in)
+            call initialize_pusher_tetra_field_lines(ind_tetr_inout,x,iface,vpar,t_remain_in)
 !
             !Initial computation values
             z = z_init

--- a/SRC/pusher_tetra_field_lines_mod.f90
+++ b/SRC/pusher_tetra_field_lines_mod.f90
@@ -55,13 +55,14 @@ module pusher_tetra_field_lines_mod
             !Sign of the right hand side of ODE - ensures that tau is ALWAYS positive inside the algorithm
             sign_rhs = sign_sqg * int(sign(1.d0,t_remain))
 !
-            z_init(1:3)=x-tetra_physics(ind_tetr)%x1       !x is the entry point of the particle into the tetrahedron in (R,phi,z)-coordinates
+            !z_init(1:3): position relative to the 1st vertex of the tetrahedron (new origin)
+            !x is the entry point of the particle into the tetrahedron in (R,phi,z)-coordinates
+            z_init(1:3)=x-tetra_physics(ind_tetr)%x1
 !
-            z_init(4)=vpar                         !Transform to z_init: 1st vertex of tetrahdron is new origin
+            z_init(4)=vpar
 !
             !Save initial orbit parameters
             x_init = x
-!             vperp_init = vperp
             iface_init = iface
 !
             !Tetrahedron constants
@@ -76,11 +77,9 @@ module pusher_tetra_field_lines_mod
             !Phi at the entry point of the particle
             phi_elec = phi_elec_func(z_init(1:3),ind_tetr)   !tetra_physics(ind_tetr)%Phi1+sum(tetra_physics(ind_tetr)%gPhi*z_init(1:3))
 !
-            !Auxiliary quantities
+            !Auxiliary quantities (unused by the field-line pusher itself, kept for diagnostics)
             vperp2 = -2.d0*perpinv*bmod0
             vpar2 = vpar**2
-            !This is the total speed viewed in the MOVING FRAME of ExB drift (here it only acts as a coefficient for the EOM-set)
-            !For physical estimates v_E is considered seperately anyway
             vmod0 = sqrt(vpar2+vperp2)
 !
             k1 = vperp2+vpar2+2.d0*perpinv*tetra_physics(ind_tetr)%bmod1
@@ -149,10 +148,10 @@ endif
             boole_faces = .true.
 !
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            !!!!!!!!!!!!!!!!!!!!FIRST ATTEMPT WITH SECOND ORDER GUESS!!!!!!!!!!!!!!!!!!!!
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!PUSH TO EXIT FACE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
-            !Analytical calculation of orbit parameter to guess exit face and estimate of tau
+            !Analytical (linear) solve for exit face and tau
             call analytic_approx(boole_faces,z,iface_new,tau,boole_analytical_approx)
 !
 if(diag_pusher_tetry_poly) print *, 'boole_analytical_approx',boole_analytical_approx
@@ -176,7 +175,7 @@ if(diag_pusher_tetry_poly) print *, 'Error in predicted integrator: Analytic app
             endif !boole face correct
 !
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            !!!!!!!!!!!!!!!!!!!!!!!!!!END OF FIRST ATTEMPT!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            !!!!!!!!!!!!!!!!!!!!!!!!END OF PUSH TO EXIT FACE!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
 if(diag_pusher_tetry_poly) then
@@ -208,7 +207,7 @@ if(diag_pusher_tetry_poly) print *, 't_pass',t_pass
             if(abs(t_pass).ge.abs(t_remain)) then
 !
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            !!!!!!!SECOND ATTEMPT IF PARTICLE DOES NOT LEAVE CELL IN REMAINING TIME!!!!!!!
+            !!!!!!!FALLBACK: PARTICLE DOES NOT LEAVE CELL IN REMAINING TIME!!!!!!!!!!!!!!
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
                 !Set z back to z_init
@@ -248,7 +247,7 @@ if(diag_pusher_tetry_poly) print *, 'tau until t finished',tau
                 endif
 !
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            !!!!!!!!!!!!END OF SECOND ATTEMPT IF PARTICLE DOES NOT LEAVE CELL!!!!!!!!!!!!
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!END OF FALLBACK!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
             !Normal orbit that passes the whole tetrahedron

--- a/TESTS/CMakeLists.txt
+++ b/TESTS/CMakeLists.txt
@@ -21,3 +21,16 @@ GORILLA_ROOT=${CMAKE_SOURCE_DIR}/../GORILLA;\
 GORILLA_APPLETS_BIN=$<TARGET_FILE:gorilla_applets_main.x>;\
 WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/alpha_lifetime_work"
 )
+
+add_test(
+    NAME field_line_tracing
+    COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test_field_line_tracing.py
+)
+set_tests_properties(field_line_tracing PROPERTIES
+    ENVIRONMENT
+        "APPLETS_ROOT=${CMAKE_SOURCE_DIR};\
+GORILLA_ROOT=${CMAKE_SOURCE_DIR}/../GORILLA;\
+GORILLA_APPLETS_BIN=$<TARGET_FILE:gorilla_applets_main.x>;\
+WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/field_line_tracing_work"
+)

--- a/TESTS/test_field_line_tracing.py
+++ b/TESTS/test_field_line_tracing.py
@@ -80,14 +80,11 @@ field_line_tracing["field_line_tracing_nml"]["n_particles"] = 3
 field_line_tracing["field_line_tracing_nml"]["boole_poincare_plot"] = False
 field_line_tracing["field_line_tracing_nml"]["boole_divertor_intersection"] = False
 field_line_tracing["field_line_tracing_nml"]["boole_point_source"] = False
-field_line_tracing["field_line_tracing_nml"]["boole_collisions"] = False
-field_line_tracing["field_line_tracing_nml"]["boole_precalc_collisions"] = False
 field_line_tracing["field_line_tracing_nml"]["boole_refined_sqrt_g"] = True
 field_line_tracing["field_line_tracing_nml"]["boole_monoenergetic"] = True
 field_line_tracing["field_line_tracing_nml"]["boole_linear_density_simulation"] = False
 field_line_tracing["field_line_tracing_nml"]["boole_linear_temperature_simulation"] = False
 field_line_tracing["field_line_tracing_nml"]["seed_option"] = 2
-field_line_tracing["field_line_tracing_nml"]["density"] = 1.0
 
 # Deterministic seed for reproducible CI output
 (WORK_DIR / "seed.inp").write_text("8\n  1 2 3 4 5 6 7 8\n")

--- a/TESTS/test_field_line_tracing.py
+++ b/TESTS/test_field_line_tracing.py
@@ -89,24 +89,10 @@ field_line_tracing["field_line_tracing_nml"]["seed_option"] = 2
 # Deterministic seed for reproducible CI output
 (WORK_DIR / "seed.inp").write_text("8\n  1 2 3 4 5 6 7 8\n")
 
-# Minimal field_divB0.inp: ipert = 0 (axisymmetric equilibrium only, no perturbation data)
-# gfile, convexfile and iaxieq are overridden from tetra_grid_settings_mod, so their
+# Axisymmetric equilibrium only (ipert = 0 in the upstream blueprint); gfile,
+# convexfile and iaxieq are overridden from tetra_grid_settings_mod, so their
 # values are read into a dummy and ignored.
-(WORK_DIR / "field_divB0.inp").write_text(
-    "0                                 ipert\n"
-    "1                                 iequil\n"
-    "0.0                               ampl\n"
-    "0 0                               ntor\n"
-    "0.99                              cutoff\n"
-    "4                                 icftype\n"
-    "'unused'                          gfile\n"
-    "'unused'                          pfile\n"
-    "'unused'                          convexfile\n"
-    "'unused'                          fluxdatapath\n"
-    "0                                 window R\n"
-    "0                                 window Z\n"
-    "0                                 iaxieq\n"
-)
+shutil.copy(GORILLA_ROOT / "INPUT" / "field_divB0.inp", WORK_DIR / "field_divB0.inp")
 
 # Symlink the bundled ASDEX g-file + convex wall into the work dir
 (WORK_DIR / "DATA").mkdir()

--- a/TESTS/test_field_line_tracing.py
+++ b/TESTS/test_field_line_tracing.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+CTest driver for the field-line tracing CI test.
+
+Reads GORILLA-core blueprints from ../GORILLA/INPUT/ and applet blueprints
+from GORILLA_APPLETS/INPUT/, sets every key the test depends on explicitly,
+then invokes the binary with i_option = 10 (field line tracing).
+
+The test uses the bundled ASDEX g-file (grid_kind = 1, axisymmetric EFIT)
+so it does not depend on the VMEC equilibrium files from the GORILLA repo.
+
+Paths are passed in by TESTS/CMakeLists.txt via environment variables.
+"""
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import f90nml
+except ImportError:
+    sys.exit("f90nml is required to run this test (pip install f90nml)")
+
+
+def env_path(name: str) -> Path:
+    value = os.environ.get(name)
+    if not value:
+        sys.exit(f"missing required env var: {name}")
+    return Path(value)
+
+
+APPLETS_ROOT = env_path("APPLETS_ROOT")
+GORILLA_ROOT = env_path("GORILLA_ROOT")
+BINARY = env_path("GORILLA_APPLETS_BIN")
+WORK_DIR = env_path("WORK_DIR")
+
+ASDEX_DIR = APPLETS_ROOT / "INPUT" / "data_files" / "DATA" / "ASDEX"
+
+# Fresh work dir for every test run
+if WORK_DIR.exists():
+    shutil.rmtree(WORK_DIR)
+WORK_DIR.mkdir(parents=True)
+
+# Load blueprints from their conceptual owners
+gorilla = f90nml.read(str(GORILLA_ROOT / "INPUT" / "gorilla.inp"))
+tetra_grid = f90nml.read(str(GORILLA_ROOT / "INPUT" / "tetra_grid.inp"))
+gorilla_applets = f90nml.read(str(APPLETS_ROOT / "INPUT" / "gorilla_applets.inp"))
+field_line_tracing = f90nml.read(str(APPLETS_ROOT / "INPUT" / "field_line_tracing.inp"))
+for nml in (gorilla, tetra_grid, gorilla_applets, field_line_tracing):
+    nml.end_comma = True
+
+# Core integrator (cylindrical coords, polynomial pusher, cheap order for CI)
+gorilla["gorillanml"]["eps_phi"] = 0.0
+gorilla["gorillanml"]["coord_system"] = 1            # (R, phi, Z)
+gorilla["gorillanml"]["ispecies"] = 2                # deuterium
+gorilla["gorillanml"]["boole_periodic_relocation"] = True
+gorilla["gorillanml"]["ipusher"] = 2                 # polynomial pusher
+gorilla["gorillanml"]["poly_order"] = 2
+gorilla["gorillanml"]["boole_guess"] = True
+gorilla["gorillanml"]["boole_grid_for_find_tetra"] = False
+gorilla["gorillanml"]["boole_adaptive_time_steps"] = False
+
+# Tetrahedral grid: rectangular EFIT, small for CI
+tetra_grid["tetra_grid_nml"]["grid_kind"] = 1        # rectangular EFIT
+tetra_grid["tetra_grid_nml"]["n1"] = 20              # nR
+tetra_grid["tetra_grid_nml"]["n2"] = 4               # nphi
+tetra_grid["tetra_grid_nml"]["n3"] = 20              # nZ
+tetra_grid["tetra_grid_nml"]["boole_n_field_periods"] = True
+tetra_grid["tetra_grid_nml"]["g_file_filename"] = "DATA/ASDEX/g26884.4300"
+tetra_grid["tetra_grid_nml"]["convex_wall_filename"] = "DATA/ASDEX/convexwall.dat"
+
+# Applets dispatcher
+gorilla_applets["gorilla_applets_nml"]["i_option"] = 10
+
+# Field line tracing: cheap, no poincare/divertor/collisions
+field_line_tracing["field_line_tracing_nml"]["time_step"] = 1.0e-4
+field_line_tracing["field_line_tracing_nml"]["energy_ev"] = 3.5e3
+field_line_tracing["field_line_tracing_nml"]["n_particles"] = 3
+field_line_tracing["field_line_tracing_nml"]["boole_poincare_plot"] = False
+field_line_tracing["field_line_tracing_nml"]["boole_divertor_intersection"] = False
+field_line_tracing["field_line_tracing_nml"]["boole_point_source"] = False
+field_line_tracing["field_line_tracing_nml"]["boole_collisions"] = False
+field_line_tracing["field_line_tracing_nml"]["boole_precalc_collisions"] = False
+field_line_tracing["field_line_tracing_nml"]["boole_refined_sqrt_g"] = True
+field_line_tracing["field_line_tracing_nml"]["boole_monoenergetic"] = True
+field_line_tracing["field_line_tracing_nml"]["boole_linear_density_simulation"] = False
+field_line_tracing["field_line_tracing_nml"]["boole_linear_temperature_simulation"] = False
+field_line_tracing["field_line_tracing_nml"]["seed_option"] = 2
+field_line_tracing["field_line_tracing_nml"]["density"] = 1.0
+
+# Deterministic seed for reproducible CI output
+(WORK_DIR / "seed.inp").write_text("8\n  1 2 3 4 5 6 7 8\n")
+
+# Minimal field_divB0.inp: ipert = 0 (axisymmetric equilibrium only, no perturbation data)
+# gfile, convexfile and iaxieq are overridden from tetra_grid_settings_mod, so their
+# values are read into a dummy and ignored.
+(WORK_DIR / "field_divB0.inp").write_text(
+    "0                                 ipert\n"
+    "1                                 iequil\n"
+    "0.0                               ampl\n"
+    "0 0                               ntor\n"
+    "0.99                              cutoff\n"
+    "4                                 icftype\n"
+    "'unused'                          gfile\n"
+    "'unused'                          pfile\n"
+    "'unused'                          convexfile\n"
+    "'unused'                          fluxdatapath\n"
+    "0                                 window R\n"
+    "0                                 window Z\n"
+    "0                                 iaxieq\n"
+)
+
+# Symlink the bundled ASDEX g-file + convex wall into the work dir
+(WORK_DIR / "DATA").mkdir()
+(WORK_DIR / "DATA" / "ASDEX").symlink_to(ASDEX_DIR, target_is_directory=True)
+
+# Write namelists
+gorilla.write(str(WORK_DIR / "gorilla.inp"), force=True)
+tetra_grid.write(str(WORK_DIR / "tetra_grid.inp"), force=True)
+gorilla_applets.write(str(WORK_DIR / "gorilla_applets.inp"), force=True)
+field_line_tracing.write(str(WORK_DIR / "field_line_tracing.inp"), force=True)
+
+print("=== field line tracing: i_option=10 ===", flush=True)
+result = subprocess.run(
+    [str(BINARY)],
+    cwd=WORK_DIR,
+    capture_output=True,
+    text=True,
+    check=False,
+)
+print(result.stdout)
+if result.stderr:
+    print(result.stderr, file=sys.stderr)
+if result.returncode != 0:
+    sys.exit(f"FAIL: gorilla_applets_main.x exited with code {result.returncode}")
+
+# Smoke check: the final summary stanza must be present
+expected_marker = "Number of lost particles"
+if expected_marker not in result.stdout:
+    sys.exit(f"FAIL: expected '{expected_marker}' in stdout but it was missing")
+
+print(f"PASS: field line tracing completed and summary marker found")


### PR DESCRIPTION
## Summary

Addresses issues #9 (refactor `field_line_tracing_mod` to reuse `boltzmann_supporting_functions_mod` successors) and #10 (adapt comments inherited from `pusher_tetra_poly`), plus follow-up cleanups and a CI test mirroring `alpha_lifetime`.

- **#9**: replace the inline `field_divB0.inp` parse and the inline seed read with `get_ipert` / `set_seed_for_random_numbers` from `utils_data_pre_and_post_processing_mod` (the surviving destinations of the deleted `boltzmann_supporting_functions_mod`, split in 6921a8d). Other ex-boltzmann routines had divergent signatures and were not worth dragging in.
- **#10**: adapt the copy-pasted `pusher_tetra_poly` banner comments (`FIRST ATTEMPT WITH SECOND ORDER GUESS` → `PUSH TO EXIT FACE`, etc.); rename `initialize_pusher_tetra_poly` → `initialize_pusher_tetra_field_lines`; drop module/local dead state (`vmod0`, `k1`, `k3`, `bmod0`, `perpinv`, `vperp2`, `vpar2`, `phi_elec`, `tau_*`, `energy_*`, `i_step_root`, `t_remain_new`, `z_dummy`, …) and now-unused imports.
- **CI**: new `test_field_line_tracing.py` mirrors `test_alpha_lifetime.py` — `grid_kind=1` rectangular EFIT with the bundled ASDEX g-file, 20×4×20 grid, 3 particles, asserts the final summary stanza is present.
- **Collision strip**: remove the `boole_collisions` / `boole_precalc_collisions` / `density` code path from `field_line_tracing_mod`. It was never enabled in any input or example, and is physically pointless here (the field-line pusher advances along `curl(A)` at a rate ∝ `vpar`, so collisions only rescale traversal speed, not the 3D trajectory). Verified no-op by comparing a 100-particle full run: `poincare_maps.dat` and `fort.75` are byte-identical pre/post, and stdout counters (avg pushings 6539.05, 71 lost, 29 survived) match exactly.

Based on `ci/alpha-lifetime` (PR #34); auto-retargets to `main` when that merges.

## Test plan

- [x] `make` clean
- [x] `ctest -R field_line_tracing` passes (smoke)
- [x] 100-particle full run with poincare output: byte-identical `poincare_maps.dat` and `fort.75` pre vs post collision strip
- [x] `ctest -R alpha_lifetime` still passes