### PR TITLE
Add helical-core smoke test, blueprint, and README rows

### DIFF
--- a/INPUT/helical_core.inp
+++ b/INPUT/helical_core.inp
@@ -1,0 +1,80 @@
+! INPUT FILE FOR HELICAL CORE PARTICLE TRACING
+!
+&helical_core_nml
+!
+  !time for tracing particles (in seconds)
+  time_step = 2.0d-3,!1.0d-1 ,
+!
+  !Kinetic energy of particles (in eV)
+  energy_eV = 1.0d3,!2.0d3 ,
+!
+  !Number of species (usually 1)
+  n_species = 1
+!
+  !Number of particles to be traced
+  n_particles = 1.0d3,!1.0d5 ,
+!
+  !Compute squares of moments
+  boole_squared_moments = .false.,
+!
+  !Start all particles from the same physical position
+  boole_point_source = .false.,
+!
+  !include a collision operator
+  boole_collisions = .true.,
+!
+  !precalcualte random numbers for collisions
+  boole_precalc_collisions = .false.,
+!
+  !make collisions energy and momentum conserving
+  boole_preserve_energy_and_momentum_during_collisions = .false.,
+!
+  !Simulated density of particles
+  density = 3.0d13,
+!
+  !refined jacobian determinant
+  boole_refined_sqrt_g = .true.,
+!
+  !work with monoenergetic particles instead of with boltzmann energies
+  boole_monoenergetic = .true.,
+!
+  !make density a linear function of poloidal flux
+  boole_linear_density_simulation = .false.,
+!
+  !Eliminate particles starting outside a flux surface threshold
+  !boole_eliminate_particles_outside_flux = .true. enables elimination
+  !flux_threshold_for_elimination = normalized flux value (0=axis, 1=boundary)
+  !Particles with normalized poloidal flux > threshold are eliminated at start
+  boole_eliminate_particles_outside_flux = .false.,
+  flux_threshold_for_elimination = 0.5d0,
+!
+  !Use delta-f method for particle weights
+  boole_delta_f = .true.,
+!
+  !always initiate pairs of particles where both particles start at the same position but move
+  !in opposite direction, this helps to reduce statistical noise
+  boole_antithetic_variate = .true.,
+!
+  !make temperature a linear function of poloidal flux
+  boole_linear_temperature_simulation = .false.,
+!
+  !Set integrator type
+  ! 1 ... GORILLA
+  ! 2 ... DIRECT
+  i_integrator_type = 1 ,
+!
+  !Option for precomputation of above random numbers
+  ! 1 ... compute seed with a random number
+  ! 2 ... load seed from file 'seed.inp'
+  seed_option = 2
+
+  !write data to files
+  boole_write_vertex_indices = .true. ,
+  boole_write_vertex_coordinates = .true. ,
+  boole_write_prism_volumes = .true. ,
+  boole_write_refined_prism_volumes = .false. ,
+  boole_write_moments = .true. ,
+  boole_write_fourier_moments = .true. ,
+  boole_write_exit_data = .true. ,
+  boole_write_grid_data = .true.
+/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Selected at runtime via `gorilla_applets_nml/i_option` in `gorilla_applets.inp`:
 | 10 | Field-line tracing |
 | 11 | Divertor heat loads |
 | 12 | Self-consistent electric field |
+| 13 | Anomalous transport |
+| 14 | Helical core particle tracing |
 
 ## Building
 

--- a/TESTS/CMakeLists.txt
+++ b/TESTS/CMakeLists.txt
@@ -60,3 +60,17 @@ GORILLA_ROOT=${CMAKE_SOURCE_DIR}/../GORILLA;\
 GORILLA_APPLETS_BIN=$<TARGET_FILE:gorilla_applets_main.x>;\
 WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/helical_core_work"
 )
+
+add_test(
+    NAME helical_core_rectangular
+    COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test_helical_core.py
+)
+set_tests_properties(helical_core_rectangular PROPERTIES
+    ENVIRONMENT
+        "APPLETS_ROOT=${CMAKE_SOURCE_DIR};\
+GORILLA_ROOT=${CMAKE_SOURCE_DIR}/../GORILLA;\
+GORILLA_APPLETS_BIN=$<TARGET_FILE:gorilla_applets_main.x>;\
+WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/helical_core_rectangular_work;\
+HELICAL_CORE_GRID_KIND=1"
+)

--- a/TESTS/CMakeLists.txt
+++ b/TESTS/CMakeLists.txt
@@ -47,3 +47,16 @@ GORILLA_ROOT=${CMAKE_SOURCE_DIR}/../GORILLA;\
 GORILLA_APPLETS_BIN=$<TARGET_FILE:gorilla_applets_main.x>;\
 WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/mono_energetic_transport_work"
 )
+
+add_test(
+    NAME helical_core
+    COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test_helical_core.py
+)
+set_tests_properties(helical_core PROPERTIES
+    ENVIRONMENT
+        "APPLETS_ROOT=${CMAKE_SOURCE_DIR};\
+GORILLA_ROOT=${CMAKE_SOURCE_DIR}/../GORILLA;\
+GORILLA_APPLETS_BIN=$<TARGET_FILE:gorilla_applets_main.x>;\
+WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/helical_core_work"
+)

--- a/TESTS/test_helical_core.py
+++ b/TESTS/test_helical_core.py
@@ -6,12 +6,10 @@ Reads GORILLA-core blueprints from ../GORILLA/INPUT/ and applet blueprints
 from GORILLA_APPLETS/INPUT/, sets every key the test depends on explicitly,
 then invokes the binary with i_option = 14 (helical core particle tracing).
 
-The test uses the shared field-aligned EFIT test equilibrium
-(grid_kind = 2 with MHD_EQUILIBRIA/g_file_for_test and the SYNCH preload),
-the configuration the shipped example runs; the rectangular EFIT grid
-aborts inside the option-14 volume integrals. It covers the option-14
-execution path, not helical-core physics: the perturbation stays off,
-matching the shipped example.
+The test uses the shared EFIT test equilibrium. HELICAL_CORE_GRID_KIND selects
+the field-aligned or rectangular mesh. It covers the option-14 execution path,
+not helical-core physics: the perturbation stays off, matching the shipped
+example.
 
 Paths are passed in by TESTS/CMakeLists.txt via environment variables.
 """
@@ -38,6 +36,7 @@ APPLETS_ROOT = env_path("APPLETS_ROOT")
 GORILLA_ROOT = env_path("GORILLA_ROOT")
 BINARY = env_path("GORILLA_APPLETS_BIN")
 WORK_DIR = env_path("WORK_DIR")
+GRID_KIND = int(os.environ.get("HELICAL_CORE_GRID_KIND", "2"))
 
 # Fresh work dir for every test run
 if WORK_DIR.exists():
@@ -63,8 +62,8 @@ gorilla["gorillanml"]["boole_guess"] = True
 gorilla["gorillanml"]["boole_grid_for_find_tetra"] = False
 gorilla["gorillanml"]["boole_adaptive_time_steps"] = False
 
-# Tetrahedral grid: field-aligned EFIT as in the shipped example, small
-tetra_grid["tetra_grid_nml"]["grid_kind"] = 2        # field-aligned EFIT
+# Tetrahedral grid: shared EFIT, small enough for CI
+tetra_grid["tetra_grid_nml"]["grid_kind"] = GRID_KIND
 tetra_grid["tetra_grid_nml"]["n1"] = 20
 tetra_grid["tetra_grid_nml"]["n2"] = 30
 tetra_grid["tetra_grid_nml"]["n3"] = 50

--- a/TESTS/test_helical_core.py
+++ b/TESTS/test_helical_core.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+CTest driver for the helical-core CI smoke test.
+
+Reads GORILLA-core blueprints from ../GORILLA/INPUT/ and applet blueprints
+from GORILLA_APPLETS/INPUT/, sets every key the test depends on explicitly,
+then invokes the binary with i_option = 14 (helical core particle tracing).
+
+The test uses the shared field-aligned EFIT test equilibrium
+(grid_kind = 2 with MHD_EQUILIBRIA/g_file_for_test and the SYNCH preload),
+the configuration the shipped example runs; the rectangular EFIT grid
+aborts inside the option-14 volume integrals. It covers the option-14
+execution path, not helical-core physics: the perturbation stays off,
+matching the shipped example.
+
+Paths are passed in by TESTS/CMakeLists.txt via environment variables.
+"""
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import f90nml
+except ImportError:
+    sys.exit("f90nml is required to run this test (pip install f90nml)")
+
+
+def env_path(name: str) -> Path:
+    value = os.environ.get(name)
+    if not value:
+        sys.exit(f"missing required env var: {name}")
+    return Path(value)
+
+
+APPLETS_ROOT = env_path("APPLETS_ROOT")
+GORILLA_ROOT = env_path("GORILLA_ROOT")
+BINARY = env_path("GORILLA_APPLETS_BIN")
+WORK_DIR = env_path("WORK_DIR")
+
+# Fresh work dir for every test run
+if WORK_DIR.exists():
+    shutil.rmtree(WORK_DIR)
+WORK_DIR.mkdir(parents=True)
+
+# Load blueprints from their conceptual owners
+gorilla = f90nml.read(str(GORILLA_ROOT / "INPUT" / "gorilla.inp"))
+tetra_grid = f90nml.read(str(GORILLA_ROOT / "INPUT" / "tetra_grid.inp"))
+gorilla_applets = f90nml.read(str(APPLETS_ROOT / "INPUT" / "gorilla_applets.inp"))
+helical_core = f90nml.read(str(APPLETS_ROOT / "INPUT" / "helical_core.inp"))
+for nml in (gorilla, tetra_grid, gorilla_applets, helical_core):
+    nml.end_comma = True
+
+# Core integrator (cylindrical coords, polynomial pusher, cheap order for CI)
+gorilla["gorillanml"]["eps_phi"] = 0.0
+gorilla["gorillanml"]["coord_system"] = 1            # (R, phi, Z)
+gorilla["gorillanml"]["ispecies"] = 2                # deuterium
+gorilla["gorillanml"]["boole_periodic_relocation"] = True
+gorilla["gorillanml"]["ipusher"] = 2                 # polynomial pusher
+gorilla["gorillanml"]["poly_order"] = 2
+gorilla["gorillanml"]["boole_guess"] = True
+gorilla["gorillanml"]["boole_grid_for_find_tetra"] = False
+gorilla["gorillanml"]["boole_adaptive_time_steps"] = False
+
+# Tetrahedral grid: field-aligned EFIT as in the shipped example, small
+tetra_grid["tetra_grid_nml"]["grid_kind"] = 2        # field-aligned EFIT
+tetra_grid["tetra_grid_nml"]["n1"] = 20
+tetra_grid["tetra_grid_nml"]["n2"] = 30
+tetra_grid["tetra_grid_nml"]["n3"] = 50
+tetra_grid["tetra_grid_nml"]["boole_n_field_periods"] = True
+tetra_grid["tetra_grid_nml"]["g_file_filename"] = "MHD_EQUILIBRIA/g_file_for_test"
+tetra_grid["tetra_grid_nml"]["convex_wall_filename"] = "MHD_EQUILIBRIA/convex_wall_for_test.dat"
+
+# Applets dispatcher
+gorilla_applets["gorilla_applets_nml"]["i_option"] = 14
+
+# Helical core: few antithetic particle pairs, short trace, delta-f weights
+helical_core["helical_core_nml"]["time_step"] = 1.0e-4
+helical_core["helical_core_nml"]["energy_ev"] = 1.0e3
+helical_core["helical_core_nml"]["n_species"] = 1
+helical_core["helical_core_nml"]["n_particles"] = 4
+helical_core["helical_core_nml"]["boole_squared_moments"] = False
+helical_core["helical_core_nml"]["boole_point_source"] = False
+helical_core["helical_core_nml"]["boole_collisions"] = True
+helical_core["helical_core_nml"]["boole_precalc_collisions"] = False
+helical_core["helical_core_nml"]["boole_refined_sqrt_g"] = True
+helical_core["helical_core_nml"]["boole_monoenergetic"] = True
+helical_core["helical_core_nml"]["boole_linear_density_simulation"] = False
+helical_core["helical_core_nml"]["boole_linear_temperature_simulation"] = False
+helical_core["helical_core_nml"]["boole_eliminate_particles_outside_flux"] = False
+helical_core["helical_core_nml"]["boole_delta_f"] = True
+helical_core["helical_core_nml"]["boole_antithetic_variate"] = True
+helical_core["helical_core_nml"]["i_integrator_type"] = 1
+helical_core["helical_core_nml"]["seed_option"] = 2
+helical_core["helical_core_nml"]["boole_write_moments"] = True
+helical_core["helical_core_nml"]["boole_write_fourier_moments"] = True
+helical_core["helical_core_nml"]["boole_write_exit_data"] = True
+helical_core["helical_core_nml"]["boole_write_grid_data"] = True
+
+# Deterministic seed for reproducible CI output
+(WORK_DIR / "seed.inp").write_text("8\n  1 2 3 4 5 6 7 8\n")
+
+# Axisymmetric equilibrium only (ipert = 0 in the upstream blueprint);
+# the field-aligned grid additionally needs the SYNCH preload namelist.
+shutil.copy(GORILLA_ROOT / "INPUT" / "field_divB0.inp", WORK_DIR / "field_divB0.inp")
+shutil.copy(GORILLA_ROOT / "INPUT" / "preload_for_SYNCH.inp",
+            WORK_DIR / "preload_for_SYNCH.inp")
+
+# Symlink the shared test equilibrium into the work dir
+(WORK_DIR / "MHD_EQUILIBRIA").symlink_to(
+    GORILLA_ROOT / "MHD_EQUILIBRIA", target_is_directory=True)
+
+# Write namelists
+gorilla.write(str(WORK_DIR / "gorilla.inp"), force=True)
+tetra_grid.write(str(WORK_DIR / "tetra_grid.inp"), force=True)
+gorilla_applets.write(str(WORK_DIR / "gorilla_applets.inp"), force=True)
+helical_core.write(str(WORK_DIR / "helical_core.inp"), force=True)
+
+print("=== helical core: i_option=14 ===", flush=True)
+result = subprocess.run(
+    [str(BINARY)],
+    cwd=WORK_DIR,
+    capture_output=True,
+    text=True,
+    check=False,
+)
+print(result.stdout)
+if result.stderr:
+    print(result.stderr, file=sys.stderr)
+if result.returncode != 0:
+    sys.exit(f"FAIL: gorilla_applets_main.x exited with code {result.returncode}")
+
+# Smoke check: the final summary stanza must be present
+expected_marker = "Number of lost ions"
+if expected_marker not in result.stdout:
+    sys.exit(f"FAIL: expected '{expected_marker}' in stdout but it was missing")
+
+print("PASS: helical core tracing completed and summary marker found")


### PR DESCRIPTION
First step toward finishing the tracked helical-core application (`i_option = 14`): CI coverage on both EFIT grid types, the missing input blueprint, and the missing documentation rows.

- `TESTS/test_helical_core.py` and CTest registration build isolated work directories from the INPUT blueprints. The tests run option 14 on the shared field-aligned and rectangular EFIT meshes with four antithetic delta-f particles, collisions enabled, a deterministic seed, and a short trace. Both require a clean exit and the final summary stanza.
- `INPUT/helical_core.inp` supplies the blueprint every other applet namelist already has.
- `README.md` documents options 13 and 14.

The field-aligned setup requires `preload_for_SYNCH.inp`; the driver copies it explicitly. A previously observed rectangular-grid floating-point exception does not reproduce on this pinned branch, so the rectangular configuration is retained as a regression instead of adding a numerical fallback. No orbit, collision, volume-integration, coordinate, unit, boundary-condition, or random-sampling behavior changes.

## Verification

Before, `rg helical_core TESTS/` on main returned no option-14 test. Omitting the SYNCH preload from the new driver failed with:
```text
FAIL: gorilla_applets_main.x exited with code 2
```

After:
```text
1/2 Test #5: helical_core ..................... Passed
2/2 Test #6: helical_core_rectangular ......... Passed
100% tests passed, 0 tests failed out of 2
Static: OK (97 modules, 97 changed, 97 affected)
Build: OK
Lint: OK
All stages passed (.3s)
```

Commands:
```sh
ctest --test-dir BUILD -R "^helical_core(_rectangular)?$" --output-on-failure
fo
```