### PR TITLE
Parameterize helical-core density profile

### DIFF
--- a/EXAMPLES/helical_core/helical_core.inp
+++ b/EXAMPLES/helical_core/helical_core.inp
@@ -32,6 +32,9 @@
   !Simulated density of particles
   density = 3.0d13,
 !
+  !Normalized flux where the linear density extrapolates to zero; must exceed 1
+  linear_density_zero = 1.1d0,
+!
   !refined jacobian determinant
   boole_refined_sqrt_g = .true.,
 !

--- a/INPUT/helical_core.inp
+++ b/INPUT/helical_core.inp
@@ -32,6 +32,9 @@
   !Simulated density of particles
   density = 3.0d13,
 !
+  !Normalized flux where the linear density extrapolates to zero; must exceed 1
+  linear_density_zero = 1.1d0,
+!
   !refined jacobian determinant
   boole_refined_sqrt_g = .true.,
 !

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(GORILLA_APPLETS STATIC
   anomalous_transport/anomalous_transport_displacement_mod.f90
   anomalous_transport/utils_anomalous_transport_mod.f90
   anomalous_transport/anomalous_transport_mod.f90
+  helical_core/helical_core_profile_mod.f90
   helical_core/utils_helical_core_mod.f90
   helical_core/helical_core_mod.f90
   volume_integrals_and_sqrt_g_mod.f90

--- a/SRC/gorilla_applets_types_mod.f90
+++ b/SRC/gorilla_applets_types_mod.f90
@@ -92,6 +92,7 @@ module gorilla_applets_types_mod
     real(dp) :: energy_eV
     real(dp) :: n_particles
     real(dp) :: density
+    real(dp) :: linear_density_zero = 1.1_dp
     logical  :: boole_squared_moments
     logical  :: boole_point_source
     logical  :: boole_collisions

--- a/SRC/helical_core/helical_core_profile_mod.f90
+++ b/SRC/helical_core/helical_core_profile_mod.f90
@@ -1,0 +1,24 @@
+module helical_core_profile_mod
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+
+    implicit none
+    private
+
+    public :: linear_density_factor, delta_f_density_weight
+
+contains
+
+    pure real(dp) function linear_density_factor(s, s_zero)
+        real(dp), intent(in) :: s, s_zero
+
+        linear_density_factor = (s_zero - s)/s_zero
+    end function linear_density_factor
+
+    pure real(dp) function delta_f_density_weight(base_weight, velocity_s, &
+            s_zero)
+        real(dp), intent(in) :: base_weight, velocity_s, s_zero
+
+        delta_f_density_weight = base_weight*velocity_s/s_zero
+    end function delta_f_density_weight
+
+end module helical_core_profile_mod

--- a/SRC/helical_core/utils_helical_core_mod.f90
+++ b/SRC/helical_core/utils_helical_core_mod.f90
@@ -25,6 +25,7 @@ subroutine read_helical_core_inp_into_type
     use gorilla_applets_types_mod, only: in
 
     real(dp) :: time_step, energy_eV, n_particles, density
+    real(dp) :: linear_density_zero
     logical :: boole_squared_moments, boole_point_source, boole_collisions, boole_precalc_collisions, boole_refined_sqrt_g, &
                boole_monoenergetic, boole_linear_density_simulation, boole_antithetic_variate, &
                boole_linear_temperature_simulation, boole_write_vertex_indices, boole_write_vertex_coordinates, &
@@ -37,21 +38,26 @@ subroutine read_helical_core_inp_into_type
     integer :: s_inp_unit
 
     NAMELIST /helical_core_nml/ time_step, energy_eV, n_particles, boole_squared_moments, boole_point_source, &
-    & boole_collisions, boole_precalc_collisions, density, boole_refined_sqrt_g, boole_monoenergetic, &
+    & boole_collisions, boole_precalc_collisions, density, linear_density_zero, &
+    & boole_refined_sqrt_g, boole_monoenergetic, &
     & boole_linear_density_simulation, boole_antithetic_variate, boole_linear_temperature_simulation, i_integrator_type, &
     & seed_option, boole_write_vertex_indices, boole_write_vertex_coordinates, boole_write_prism_volumes, &
     & boole_write_refined_prism_volumes, boole_write_moments, boole_write_fourier_moments, boole_write_exit_data, &
     & boole_write_grid_data, boole_preserve_energy_and_momentum_during_collisions, n_species, &
     & boole_eliminate_particles_outside_flux, flux_threshold_for_elimination, boole_delta_f
 
+    linear_density_zero = 1.1_dp
     open(newunit = s_inp_unit, file='helical_core.inp', status='unknown')
     read(s_inp_unit,nml=helical_core_nml)
     close(s_inp_unit)
+    if (linear_density_zero <= 1.0_dp) &
+        error stop 'helical_core: linear_density_zero must exceed 1'
 
     in%time_step = time_step
     in%energy_eV = energy_eV
     in%n_particles = n_particles
     in%density = density
+    in%linear_density_zero = linear_density_zero
     in%boole_squared_moments = boole_squared_moments
     in%boole_point_source = boole_point_source
     in%boole_collisions = boole_collisions
@@ -472,23 +478,19 @@ subroutine adapt_weights_delta_f(n, z_save, vpar, vperp, ind_tetr, species)
 !
 ! Sets particle weights for the delta-f method.
 !
-    use gorilla_applets_types_mod, only: start, in, g, weights
-    use tetra_physics_mod, only: tetra_physics
-    use volume_integrals_and_sqrt_g_mod, only: sqrt_g
-    use supporting_functions_mod, only: bmod_func
-    use constants, only: pi
+    use gorilla_applets_types_mod, only: in, weights
+    use helical_core_profile_mod, only: delta_f_density_weight
 
     integer, intent(in) :: n, ind_tetr, species
     real(dp), dimension(3), intent(in) :: z_save
     real(dp), intent(in) :: vpar, vperp
 
-    real(dp) :: v_r, base_weight, r, z
+    real(dp) :: v_r
 
     call calc_v_r(z_save, vpar, vperp, ind_tetr, v_r)
 
-    !So far, we work with densities that decline like (1.1_dp - s_value)/1.1_dp, so -v^r\partial f/\partial r turns into
-    !-v^r*1.0_dp/1.1_dp(-f)=v_r*f/1.1_dp
-    weights%w(n,species) = weights%w(n,species) * v_r /1.1_dp!vpar
+    weights%w(n, species) = delta_f_density_weight(weights%w(n, species), &
+        v_r, in%linear_density_zero)
 
 end subroutine adapt_weights_delta_f
 
@@ -534,6 +536,7 @@ subroutine calc_particle_weights_and_jperp_helical_core(n, z_save, vpar, vperp, 
     use gorilla_settings_mod, only: coord_system
     use tetra_grid_settings_mod, only: grid_kind
     use marker_distribution_mod, only: evaluate_distribution_3d, evaluate_distribution_1d, pdf_boltzmann
+    use helical_core_profile_mod, only: linear_density_factor
 
     real(dp), intent(in) :: vpar, vperp
     real(dp), dimension(3), intent(in) :: z_save
@@ -596,8 +599,8 @@ subroutine calc_particle_weights_and_jperp_helical_core(n, z_save, vpar, vperp, 
     endif
 
     if ((.not.in%boole_delta_f).and.(in%boole_linear_density_simulation)) then
-        ! Linear density profile: n(s) ~ (1 - s), with 1.1 factor to avoid zero at boundary
-        density = density*(1.1_dp - s_value)/1.1_dp
+        density = density*linear_density_factor(s_value, &
+            in%linear_density_zero)
     endif
 
     pdf_gyroangle = 1/(2*pi)

--- a/TESTS/CMakeLists.txt
+++ b/TESTS/CMakeLists.txt
@@ -7,6 +7,14 @@ target_include_directories(test_multi_species_collision.x
 
 add_test(NAME multi_species_collision COMMAND test_multi_species_collision.x)
 
+add_executable(test_helical_core_profile.x
+    test_helical_core_profile.f90
+)
+target_link_libraries(test_helical_core_profile.x GORILLA_APPLETS)
+target_include_directories(test_helical_core_profile.x
+    PUBLIC ${CMAKE_BINARY_DIR}/SRC ${CMAKE_BINARY_DIR}/SRC_CORE)
+add_test(NAME helical_core_profile COMMAND test_helical_core_profile.x)
+
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 add_test(

--- a/TESTS/test_helical_core_profile.f90
+++ b/TESTS/test_helical_core_profile.f90
@@ -1,0 +1,39 @@
+program test_helical_core_profile
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use helical_core_profile_mod, only: linear_density_factor, &
+        delta_f_density_weight
+
+    implicit none
+
+    real(dp), parameter :: tolerance = 2.0e-13_dp
+    real(dp), parameter :: step = 1.0e-3_dp
+    real(dp) :: derivative, source, s, s_zero, velocity
+
+    s = 0.4_dp
+    s_zero = 1.25_dp
+    velocity = -0.03_dp
+    derivative = (linear_density_factor(s + step, s_zero) &
+        - linear_density_factor(s - step, s_zero))/(2.0_dp*step)
+    source = delta_f_density_weight(1.0_dp, velocity, s_zero)
+
+    call check('configured profile', linear_density_factor(s, s_zero), 0.68_dp)
+    call check('profile derivative', derivative, -1.0_dp/s_zero)
+    call check('delta-f source', source, velocity/s_zero)
+    call check('legacy default', linear_density_factor(0.4_dp, 1.1_dp), &
+        0.7_dp/1.1_dp)
+    if (delta_f_density_weight(0.7_dp, velocity, 1.1_dp) &
+        /= 0.7_dp*velocity/1.1_dp) error stop 'legacy operation order'
+
+    print '(A)', 'PASS: helical-core density profile and delta-f source agree'
+
+contains
+
+    subroutine check(label, actual, expected)
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: actual, expected
+
+        if (abs(actual - expected) > tolerance*max(1.0_dp, abs(expected))) &
+            error stop label
+    end subroutine check
+
+end program test_helical_core_profile


### PR DESCRIPTION
Replaces option 14’s hardcoded linear-density zero with `linear_density_zero` in `helical_core_nml`. The same parameter defines the full-f profile `n(s)=n0(s0-s)/s0` and the delta-f source weight `w v^s/s0`, so profile and derivative cannot drift apart. The default `s0=1.1` preserves the previous expression and operation order; values must exceed the normalized boundary `s=1`.

This is stacked on #41.

The normalized-flux convention, density units, source sign, particle weights, pusher, collision operator, metric, boundary conditions, and random sequence are unchanged at the default.

## Verification

Failing before implementation:
```text
Fatal Error: Cannot open module file ‘helical_core_profile_mod.mod’
```

Passing after implementation:
```text
PASS: helical-core density profile and delta-f source agree
1/7 Test #1: multi_species_collision .......... Passed
2/7 Test #2: helical_core_profile ............. Passed
3/7 Test #3: alpha_lifetime ................... Passed
4/7 Test #4: field_line_tracing ............... Passed
5/7 Test #5: mono_energetic_transport ......... Passed
6/7 Test #6: helical_core ..................... Passed
7/7 Test #7: helical_core_rectangular ......... Passed
100% tests passed, 0 tests failed out of 7
Static: OK (99 modules, 99 changed, 99 affected)
Build: OK
Lint: OK
All stages passed (.2s)
```

Commands:
```sh
cmake -S . -B /tmp/gorilla-applets-density-profile -G Ninja -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=/tmp/gorilla-applets-test-venv/bin/python
cmake --build /tmp/gorilla-applets-density-profile -j$(nproc)
ctest --test-dir /tmp/gorilla-applets-density-profile --output-on-failure
fo
```