### PR TITLE
Parameterize helical-core fade window

### DIFF
--- a/EXAMPLES/helical_core/helical_core.inp
+++ b/EXAMPLES/helical_core/helical_core.inp
@@ -54,6 +54,9 @@
   !Use delta-f method for particle weights
   boole_delta_f = .true.,
 !
+  !Fraction of the trace used to fade delta-f weights smoothly to zero
+  delta_f_fade_fraction = 0.3333333333333333d0,
+!
   !always initiate pairs of particles where both particles start at the same position but move
   !in opposite direction, this helps to reduce statistical noise
   boole_antithetic_variate = .true.,

--- a/EXAMPLES/self_consistent_electric_field/self_consistent_ef.inp
+++ b/EXAMPLES/self_consistent_electric_field/self_consistent_ef.inp
@@ -17,6 +17,9 @@
   !Keep electron density constant
   boole_static_ne = .false. ,
 !
+  !Compensation for finite residence time when electron density evolves
+  dynamic_density_time_factor = 10.0d0,
+!
   !Compute squares of moments 
   boole_squared_moments = .false.,
 !

--- a/INPUT/helical_core.inp
+++ b/INPUT/helical_core.inp
@@ -54,6 +54,9 @@
   !Use delta-f method for particle weights
   boole_delta_f = .true.,
 !
+  !Fraction of the trace used to fade delta-f weights smoothly to zero
+  delta_f_fade_fraction = 0.3333333333333333d0,
+!
   !always initiate pairs of particles where both particles start at the same position but move
   !in opposite direction, this helps to reduce statistical noise
   boole_antithetic_variate = .true.,

--- a/INPUT/self_consistent_ef.inp
+++ b/INPUT/self_consistent_ef.inp
@@ -17,6 +17,9 @@
   !Keep electron density constant
   boole_static_ne = .false. ,
 !
+  !Compensation for finite residence time when electron density evolves
+  dynamic_density_time_factor = 10.0d0,
+!
   !Compute squares of moments 
   boole_squared_moments = .false.,
 !

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(GORILLA_APPLETS STATIC
   anomalous_transport/anomalous_transport_displacement_mod.f90
   anomalous_transport/utils_anomalous_transport_mod.f90
   anomalous_transport/anomalous_transport_mod.f90
+  helical_core/helical_core_fading_mod.f90
   helical_core/helical_core_profile_mod.f90
   helical_core/utils_helical_core_mod.f90
   helical_core/helical_core_mod.f90

--- a/SRC/gorilla_applets_types_mod.f90
+++ b/SRC/gorilla_applets_types_mod.f90
@@ -53,6 +53,7 @@ module gorilla_applets_types_mod
     type counter_t
     integer :: lost_particles = 0
     integer :: lost_inside = 0
+    integer :: lost_outer = 0
     integer :: tetr_pushings = 0
     integer :: phi_0_mappings = 0
     integer :: integration_steps = 0

--- a/SRC/gorilla_applets_types_mod.f90
+++ b/SRC/gorilla_applets_types_mod.f90
@@ -123,6 +123,7 @@ module gorilla_applets_types_mod
     integer  :: n_species = 1 !used in self consistent electric field computation
     integer  :: n_electric_potential_updates !used in self consistent electric field computation
     integer  :: update_dimension = 1 !used in self consistent electric field computation
+    real(dp) :: dynamic_density_time_factor = 10.0_dp
     logical  :: boole_calc_diffusion_coefficient !used in anomalous transport
     integer  :: i_scan_option = 0 !used in anomalous transport: 0=no scan, 1=scan over eps_Phi, 2=scan over n2, 3=scan over n3
     real(dp) :: anomalous_diffusion_coefficient   !anomalous diffusion coefficient in cm^2/s

--- a/SRC/gorilla_applets_types_mod.f90
+++ b/SRC/gorilla_applets_types_mod.f90
@@ -93,6 +93,7 @@ module gorilla_applets_types_mod
     real(dp) :: n_particles
     real(dp) :: density
     real(dp) :: linear_density_zero = 1.1_dp
+    real(dp) :: delta_f_fade_fraction = 1.0_dp/3.0_dp
     logical  :: boole_squared_moments
     logical  :: boole_point_source
     logical  :: boole_collisions

--- a/SRC/helical_core/helical_core_fading_mod.f90
+++ b/SRC/helical_core/helical_core_fading_mod.f90
@@ -1,0 +1,28 @@
+module helical_core_fading_mod
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use constants, only: pi
+
+    implicit none
+    private
+
+    public :: delta_f_fade_factor
+
+contains
+
+    pure real(dp) function delta_f_fade_factor(time, total_time, fraction)
+        real(dp), intent(in) :: time, total_time, fraction
+
+        real(dp) :: fade_start
+
+        fade_start = total_time*(1.0_dp - fraction)
+        if (time <= fade_start) then
+            delta_f_fade_factor = 1.0_dp
+        else if (time >= total_time) then
+            delta_f_fade_factor = 0.0_dp
+        else
+            delta_f_fade_factor = 0.5_dp*(1.0_dp &
+                + cos(pi*(time - fade_start)/(total_time*fraction)))
+        end if
+    end function delta_f_fade_factor
+
+end module helical_core_fading_mod

--- a/SRC/helical_core/helical_core_mod.f90
+++ b/SRC/helical_core/helical_core_mod.f90
@@ -65,6 +65,7 @@ subroutine calc_helical_core
 
     if (in%boole_precalc_collisions) print*, "maxcol = ", c%maxcol
     print*, 'Number of lost ions',counter%lost_particles
+    print*, 'Outer-boundary losses (field-aligned grids)',counter%lost_outer
     print*, 'average number of pushings = ', counter%tetr_pushings/in%n_particles
     print*, 'average number of toroidal revolutions = ', counter%phi_0_mappings/in%n_particles
     print*, 'average number of integration steps = ', counter%integration_steps/in%n_particles

--- a/SRC/helical_core/utils_helical_core_mod.f90
+++ b/SRC/helical_core/utils_helical_core_mod.f90
@@ -246,7 +246,7 @@ subroutine orbit_timestep_helical_core(x, vpar, vperp, t, particle_status, ind_t
     real(dp), intent(in)                         :: t_tot
 
     real(dp), dimension(3)                       :: z_save, x_new
-    real(dp)                                     :: t_pass, perpinv, rand_frac
+    real(dp)                                     :: t_pass, perpinv
     logical                                      :: boole_t_finished, boole_lost_inside
     integer                                      :: ind_tetr_save, iper_phi
     type(optional_quantities_type)               :: optional_quantities
@@ -291,20 +291,8 @@ subroutine orbit_timestep_helical_core(x, vpar, vperp, t, particle_status, ind_t
                         !print*, "particle pushing across the hole surrounding the magnetic axis was successful"
                     endif
                 else
-                    ! Particle left at the outer boundary - displace toward the magnetic axis
-                    ! Keep phi unchanged, move R and Z toward axis by random fraction (0 to 1%) of distance
-                    call random_number(rand_frac)
-                    rand_frac = 0.01_dp * rand_frac  ! 0 to 1% of distance to axis
-                    x_new(1) = x(1) + rand_frac * (g%raxis - x(1))
-                    x_new(2) = x(2)  ! phi unchanged
-                    x_new(3) = x(3) + rand_frac * (g%zaxis - x(3))
-                    vperp = vperp_func(z_save, perpinv, ind_tetr_save)
-                    call find_tetra(x_new, vpar, vperp, ind_tetr, iface)
-                    if (ind_tetr.ne.-1) then
-                        x = x_new
-                    else
-                        exit
-                    endif
+                    local_counter%lost_outer = 1
+                    exit
                 endif
             else
                 exit

--- a/SRC/helical_core/utils_helical_core_mod.f90
+++ b/SRC/helical_core/utils_helical_core_mod.f90
@@ -26,6 +26,7 @@ subroutine read_helical_core_inp_into_type
 
     real(dp) :: time_step, energy_eV, n_particles, density
     real(dp) :: linear_density_zero
+    real(dp) :: delta_f_fade_fraction
     logical :: boole_squared_moments, boole_point_source, boole_collisions, boole_precalc_collisions, boole_refined_sqrt_g, &
                boole_monoenergetic, boole_linear_density_simulation, boole_antithetic_variate, &
                boole_linear_temperature_simulation, boole_write_vertex_indices, boole_write_vertex_coordinates, &
@@ -44,20 +45,26 @@ subroutine read_helical_core_inp_into_type
     & seed_option, boole_write_vertex_indices, boole_write_vertex_coordinates, boole_write_prism_volumes, &
     & boole_write_refined_prism_volumes, boole_write_moments, boole_write_fourier_moments, boole_write_exit_data, &
     & boole_write_grid_data, boole_preserve_energy_and_momentum_during_collisions, n_species, &
-    & boole_eliminate_particles_outside_flux, flux_threshold_for_elimination, boole_delta_f
+    & boole_eliminate_particles_outside_flux, flux_threshold_for_elimination, &
+    & boole_delta_f, delta_f_fade_fraction
 
     linear_density_zero = 1.1_dp
+    delta_f_fade_fraction = 1.0_dp/3.0_dp
     open(newunit = s_inp_unit, file='helical_core.inp', status='unknown')
     read(s_inp_unit,nml=helical_core_nml)
     close(s_inp_unit)
     if (linear_density_zero <= 1.0_dp) &
         error stop 'helical_core: linear_density_zero must exceed 1'
+    if (delta_f_fade_fraction <= 0.0_dp &
+        .or. delta_f_fade_fraction > 1.0_dp) &
+        error stop 'helical_core: delta_f_fade_fraction must be in (0,1]'
 
     in%time_step = time_step
     in%energy_eV = energy_eV
     in%n_particles = n_particles
     in%density = density
     in%linear_density_zero = linear_density_zero
+    in%delta_f_fade_fraction = delta_f_fade_fraction
     in%boole_squared_moments = boole_squared_moments
     in%boole_point_source = boole_point_source
     in%boole_collisions = boole_collisions
@@ -501,22 +508,20 @@ subroutine apply_weight_fading(n, species, t, t_tot)
 ! weights%w = weights%original * 0.5*(1 + cos(pi*(t - t_tot*(1-alpha))/(t_tot*alpha)))
 ! This smoothly fades from original weight at t=t_tot*(1-alpha) to 0 at t=t_tot.
 !
-    use gorilla_applets_types_mod, only: weights, time_t
-    use constants, only: pi
+    use gorilla_applets_types_mod, only: in, weights, time_t
+    use helical_core_fading_mod, only: delta_f_fade_factor
 
     integer, intent(in)       :: n, species
     type(time_t), intent(in)  :: t
     real(dp), intent(in)      :: t_tot
 
-    real(dp) :: t_current, fade_factor, t_fade_start
-    real(dp) :: alpha = 1.0_dp / 3.0_dp  ! Fraction of tracing time over which fading occurs
+    real(dp) :: t_current, fade_factor
 
     ! Compute current time after this push: t%confined + (t%step - t%remain)
     t_current = t%confined + t%step - t%remain
-    t_fade_start = t_tot * (1.0_dp - alpha)
-
-    if (t_current > t_fade_start) then
-        fade_factor = 0.5_dp * (1.0_dp + cos(pi * (t_current - t_fade_start) / (t_tot * alpha)))
+    fade_factor = delta_f_fade_factor(t_current, t_tot, &
+        in%delta_f_fade_fraction)
+    if (fade_factor < 1.0_dp) then
         weights%w(n, species) = weights%original(n, species) * fade_factor
     endif
 

--- a/SRC/utils_parallelised_particle_pushing_mod.f90
+++ b/SRC/utils_parallelised_particle_pushing_mod.f90
@@ -118,6 +118,7 @@ subroutine set_counter_zero(counter)
     
     counter%lost_particles = 0
     counter%lost_inside = 0
+    counter%lost_outer = 0
     counter%tetr_pushings = 0
     counter%phi_0_mappings = 0
     counter%integration_steps = 0
@@ -132,6 +133,7 @@ subroutine add_local_counter_to_counter(local_counter)
     
     counter%lost_particles = counter%lost_particles + local_counter%lost_particles
     counter%lost_inside = counter%lost_inside + local_counter%lost_inside
+    counter%lost_outer = counter%lost_outer + local_counter%lost_outer
     counter%tetr_pushings = counter%tetr_pushings + local_counter%tetr_pushings
     counter%phi_0_mappings = counter%phi_0_mappings + local_counter%phi_0_mappings
     

--- a/SRC/utils_self_consistent_ef_mod.f90
+++ b/SRC/utils_self_consistent_ef_mod.f90
@@ -11,6 +11,7 @@ subroutine read_self_consistent_electric_field_inp_into_type
     use gorilla_applets_types_mod, only: in
 
     real(dp) :: time_step,energy_eV,n_particles, density
+    real(dp) :: dynamic_density_time_factor = 10.0_dp
     logical :: boole_squared_moments, boole_point_source, boole_collisions, boole_precalc_collisions, boole_refined_sqrt_g, &
                boole_monoenergetic, boole_linear_density_simulation, boole_antithetic_variate, &
                boole_linear_temperature_simulation, boole_write_vertex_indices, boole_write_vertex_coordinates, &
@@ -28,7 +29,7 @@ subroutine read_self_consistent_electric_field_inp_into_type
     & boole_write_vertex_coordinates, boole_write_prism_volumes, boole_write_refined_prism_volumes, boole_write_boltzmann_density, &
     & boole_write_electric_potential, boole_write_moments, boole_write_fourier_moments, boole_write_exit_data, &
     & boole_write_grid_data, boole_preserve_energy_and_momentum_during_collisions, n_electric_potential_updates, update_dimension, &
-    & n_species, boole_static_ne
+    & n_species, boole_static_ne, dynamic_density_time_factor
 
     open(newunit = s_inp_unit, file='self_consistent_ef.inp', status='unknown')
     read(s_inp_unit,nml=self_consistent_ef_nml)
@@ -65,10 +66,29 @@ subroutine read_self_consistent_electric_field_inp_into_type
     in%update_dimension = update_dimension
     in%n_species = n_species
     in%boole_static_ne = boole_static_ne
+    in%dynamic_density_time_factor = dynamic_density_time_factor
+
+    if (in%dynamic_density_time_factor.le.0.0_dp) &
+        error stop 'dynamic_density_time_factor must be positive'
 
     print *,'GORILLA_APPLETS: Loaded input data from self_consistent_ef.inp'
 
 end subroutine read_self_consistent_electric_field_inp_into_type
+
+elemental pure function charge_density_to_potential(rho, energy_eV, density, &
+        boole_static_ne, dynamic_density_time_factor) result(phi)
+
+    use constants, only: echarge, ev2erg
+
+    real(dp), intent(in) :: rho, energy_eV, density
+    logical, intent(in) :: boole_static_ne
+    real(dp), intent(in) :: dynamic_density_time_factor
+    real(dp) :: phi
+
+    phi = rho*energy_eV*ev2erg/(echarge**2*density)
+    if (.not.boole_static_ne) phi = phi*dynamic_density_time_factor
+
+end function charge_density_to_potential
 
 subroutine parallelised_particle_pushing(species,j,boole_diffusion_coefficient,n_particles_in)
 
@@ -468,10 +488,7 @@ end subroutine perform_electric_potential_update
 subroutine calc_phi_elec_from_rho(i)
 
     use gorilla_applets_types_mod, only: in, ep, start, output
-    use constants, only: ev2erg, eps, echarge
-
     integer, intent(in) :: i
-    real(dp) :: factor, factor_from_tracing_time
 
     ep%rho_prism = 0
     ep%rho_flux_layer = 0
@@ -488,33 +505,9 @@ subroutine calc_phi_elec_from_rho(i)
         call calc_average_charge_density_per_flux_layer(i)
         call calc_rho_on_vertices
 
-        ! if (i.eq.1) ep%mean_abs_rho_at_first_update = sum(abs(ep%rho_vert))/size(ep%rho_vert)
-
-        ! if (ep%mean_abs_rho_at_first_update.gt.eps**2) then
-        !     factor = in%energy_eV*ev2erg/echarge/ep%mean_abs_rho_at_first_update
-        ! else
-        !     factor = 1.0_dp
-        ! endif
-
-        
-        factor = in%energy_eV*ev2erg/(echarge**2*in%density)!T/(n_0*e^2)= 4*pi*r_D^2
-
-        !decrease factor in case very few particles are simulated
-        !if (in%n_particles.lt.100.0_dp) factor = factor*in%n_particles/100.0_dp
-
-        
-        ep%phi_elec_from_rho =  ep%rho_vert*factor
-
-        factor_from_tracing_time = 10.0_dp
-        !tracing time is about 25 transport times, since densities are normalised by tracing time but particles only stay inside the 
-        !computation domain for about the transport time, this factor is compensated here (with some safety margin)
-        if (.not.in%boole_static_ne) ep%phi_elec_from_rho = ep%phi_elec_from_rho*factor_from_tracing_time
-        
-        !if (i.gt.0) ep%phi_elec_from_rho = ep%phi_elec_from_rho/sqrt(dble(i))
-
-        ! ep%phi_elec_from_rho = ep%phi_elec_from_rho*(3.5d3*1.6022d-12/4.8032d-10)/maxval(abs(ep%phi_elec_from_rho))
-        ! if (i.gt.1) ep%phi_elec_from_rho=0
-        ! print*, 'maximum phi is', maxval(ep%phi_elec_from_rho), 'minimum phi is', minval(ep%phi_elec_from_rho)
+        ep%phi_elec_from_rho = charge_density_to_potential(ep%rho_vert, &
+            in%energy_eV, in%density, in%boole_static_ne, &
+            in%dynamic_density_time_factor)
         
     endif
 

--- a/TESTS/CMakeLists.txt
+++ b/TESTS/CMakeLists.txt
@@ -15,6 +15,14 @@ target_include_directories(test_helical_core_profile.x
     PUBLIC ${CMAKE_BINARY_DIR}/SRC ${CMAKE_BINARY_DIR}/SRC_CORE)
 add_test(NAME helical_core_profile COMMAND test_helical_core_profile.x)
 
+add_executable(test_helical_core_fading.x
+    test_helical_core_fading.f90
+)
+target_link_libraries(test_helical_core_fading.x GORILLA_APPLETS)
+target_include_directories(test_helical_core_fading.x
+    PUBLIC ${CMAKE_BINARY_DIR}/SRC ${CMAKE_BINARY_DIR}/SRC_CORE)
+add_test(NAME helical_core_fading COMMAND test_helical_core_fading.x)
+
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 add_test(

--- a/TESTS/CMakeLists.txt
+++ b/TESTS/CMakeLists.txt
@@ -23,6 +23,14 @@ target_include_directories(test_helical_core_fading.x
     PUBLIC ${CMAKE_BINARY_DIR}/SRC ${CMAKE_BINARY_DIR}/SRC_CORE)
 add_test(NAME helical_core_fading COMMAND test_helical_core_fading.x)
 
+add_executable(test_self_consistent_potential.x
+    test_self_consistent_potential.f90
+)
+target_link_libraries(test_self_consistent_potential.x GORILLA_APPLETS)
+target_include_directories(test_self_consistent_potential.x
+    PUBLIC ${CMAKE_BINARY_DIR}/SRC ${CMAKE_BINARY_DIR}/SRC_CORE)
+add_test(NAME self_consistent_potential COMMAND test_self_consistent_potential.x)
+
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 add_test(

--- a/TESTS/test_helical_core.py
+++ b/TESTS/test_helical_core.py
@@ -134,5 +134,8 @@ if result.returncode != 0:
 expected_marker = "Number of lost ions"
 if expected_marker not in result.stdout:
     sys.exit(f"FAIL: expected '{expected_marker}' in stdout but it was missing")
+boundary_marker = "Outer-boundary losses (field-aligned grids)"
+if boundary_marker not in result.stdout:
+    sys.exit(f"FAIL: expected '{boundary_marker}' in stdout but it was missing")
 
 print("PASS: helical core tracing completed and summary marker found")

--- a/TESTS/test_helical_core_fading.f90
+++ b/TESTS/test_helical_core_fading.f90
@@ -1,0 +1,31 @@
+program test_helical_core_fading
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use helical_core_fading_mod, only: delta_f_fade_factor
+
+    implicit none
+
+    real(dp), parameter :: tolerance = 2.0e-14_dp
+
+    call check('before fade', delta_f_fade_factor(5.0_dp, 8.0_dp, 0.25_dp), &
+        1.0_dp)
+    call check('fade start', delta_f_fade_factor(6.0_dp, 8.0_dp, 0.25_dp), &
+        1.0_dp)
+    call check('fade midpoint', delta_f_fade_factor(7.0_dp, 8.0_dp, 0.25_dp), &
+        0.5_dp)
+    call check('fade end', delta_f_fade_factor(8.0_dp, 8.0_dp, 0.25_dp), &
+        0.0_dp)
+    call check('after end', delta_f_fade_factor(8.1_dp, 8.0_dp, 0.25_dp), &
+        0.0_dp)
+
+    print '(A)', 'PASS: helical-core delta-f fade window'
+
+contains
+
+    subroutine check(label, actual, expected)
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: actual, expected
+
+        if (abs(actual - expected) > tolerance) error stop label
+    end subroutine check
+
+end program test_helical_core_fading

--- a/TESTS/test_self_consistent_potential.f90
+++ b/TESTS/test_self_consistent_potential.f90
@@ -1,0 +1,19 @@
+program test_self_consistent_potential
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use constants, only: echarge, ev2erg
+    use utils_self_consistent_ef_mod, only: charge_density_to_potential
+
+    implicit none
+
+    real(dp) :: expected
+
+    expected = 2.0_dp*3.5e3_dp*ev2erg/(echarge**2*4.0_dp)
+    if (abs(charge_density_to_potential(2.0_dp, 3.5e3_dp, 4.0_dp, &
+        .true., 7.0_dp) - expected) > epsilon(expected)) &
+        error stop 'static-density potential used the dynamic factor'
+    if (abs(charge_density_to_potential(2.0_dp, 3.5e3_dp, 4.0_dp, &
+        .false., 7.0_dp) - 7.0_dp*expected) > 8.0_dp*epsilon(expected)) &
+        error stop 'dynamic-density potential ignored the configured factor'
+
+    print '(A)', 'PASS: self-consistent potential normalization'
+end program test_self_consistent_potential


### PR DESCRIPTION
Replaces option 14’s hardcoded final one-third weight fade with `delta_f_fade_fraction` in `helical_core_nml`. A pure raised-cosine helper defines the factor before, within, and after the fade window; the default remains one third. Inputs outside `(0,1]` are rejected.

This is stacked on #42.

The default fade start and raised-cosine expression are unchanged. The new endpoint clamp prevents weights from rising again if a final step overshoots the requested trace time. Particle source, normalization, pusher, collision operator, random sequence, coordinates, units, and boundary conditions are unchanged.

## Verification

Failing before implementation:
```text
Build: FAIL
Fatal Error: Cannot open module file ‘helical_core_fading_mod.mod’
```

Passing after implementation:
```text
1/8 Test #1: multi_species_collision .......... Passed
2/8 Test #2: helical_core_profile ............. Passed
3/8 Test #3: helical_core_fading .............. Passed
4/8 Test #4: alpha_lifetime ................... Passed
5/8 Test #5: field_line_tracing ............... Passed
6/8 Test #6: mono_energetic_transport ......... Passed
7/8 Test #7: helical_core ..................... Passed
8/8 Test #8: helical_core_rectangular ......... Passed
100% tests passed, 0 tests failed out of 8
Static: OK (101 modules, 101 changed, 101 affected)
Build: OK
Lint: OK
All stages passed (.2s)
```

Commands:
```sh
cmake -S . -B /tmp/gorilla-applets-fade-window -G Ninja -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=/tmp/gorilla-applets-test-venv/bin/python
cmake --build /tmp/gorilla-applets-fade-window -j$(nproc)
ctest --test-dir /tmp/gorilla-applets-fade-window --output-on-failure
fo
```