### PR TITLE
Make helical-core outer boundary absorbing

### DIFF
--- a/SRC/gorilla_applets_types_mod.f90
+++ b/SRC/gorilla_applets_types_mod.f90
@@ -53,6 +53,7 @@ module gorilla_applets_types_mod
     type counter_t
     integer :: lost_particles = 0
     integer :: lost_inside = 0
+    integer :: lost_outer = 0
     integer :: tetr_pushings = 0
     integer :: phi_0_mappings = 0
     integer :: integration_steps = 0

--- a/SRC/helical_core/helical_core_mod.f90
+++ b/SRC/helical_core/helical_core_mod.f90
@@ -65,6 +65,7 @@ subroutine calc_helical_core
 
     if (in%boole_precalc_collisions) print*, "maxcol = ", c%maxcol
     print*, 'Number of lost ions',counter%lost_particles
+    print*, 'Outer-boundary losses (field-aligned grids)',counter%lost_outer
     print*, 'average number of pushings = ', counter%tetr_pushings/in%n_particles
     print*, 'average number of toroidal revolutions = ', counter%phi_0_mappings/in%n_particles
     print*, 'average number of integration steps = ', counter%integration_steps/in%n_particles

--- a/SRC/helical_core/utils_helical_core_mod.f90
+++ b/SRC/helical_core/utils_helical_core_mod.f90
@@ -246,7 +246,7 @@ subroutine orbit_timestep_helical_core(x, vpar, vperp, t, particle_status, ind_t
     real(dp), intent(in)                         :: t_tot
 
     real(dp), dimension(3)                       :: z_save, x_new
-    real(dp)                                     :: t_pass, perpinv, rand_frac
+    real(dp)                                     :: t_pass, perpinv
     logical                                      :: boole_t_finished, boole_lost_inside
     integer                                      :: ind_tetr_save, iper_phi
     type(optional_quantities_type)               :: optional_quantities
@@ -291,20 +291,8 @@ subroutine orbit_timestep_helical_core(x, vpar, vperp, t, particle_status, ind_t
                         !print*, "particle pushing across the hole surrounding the magnetic axis was successful"
                     endif
                 else
-                    ! Particle left at the outer boundary - displace toward the magnetic axis
-                    ! Keep phi unchanged, move R and Z toward axis by random fraction (0 to 1%) of distance
-                    call random_number(rand_frac)
-                    rand_frac = 0.01_dp * rand_frac  ! 0 to 1% of distance to axis
-                    x_new(1) = x(1) + rand_frac * (g%raxis - x(1))
-                    x_new(2) = x(2)  ! phi unchanged
-                    x_new(3) = x(3) + rand_frac * (g%zaxis - x(3))
-                    vperp = vperp_func(z_save, perpinv, ind_tetr_save)
-                    call find_tetra(x_new, vpar, vperp, ind_tetr, iface)
-                    if (ind_tetr.ne.-1) then
-                        x = x_new
-                    else
-                        exit
-                    endif
+                    local_counter%lost_outer = 1
+                    exit
                 endif
             else
                 exit

--- a/SRC/utils_parallelised_particle_pushing_mod.f90
+++ b/SRC/utils_parallelised_particle_pushing_mod.f90
@@ -118,6 +118,7 @@ subroutine set_counter_zero(counter)
     
     counter%lost_particles = 0
     counter%lost_inside = 0
+    counter%lost_outer = 0
     counter%tetr_pushings = 0
     counter%phi_0_mappings = 0
     counter%integration_steps = 0
@@ -132,6 +133,7 @@ subroutine add_local_counter_to_counter(local_counter)
     
     counter%lost_particles = counter%lost_particles + local_counter%lost_particles
     counter%lost_inside = counter%lost_inside + local_counter%lost_inside
+    counter%lost_outer = counter%lost_outer + local_counter%lost_outer
     counter%tetr_pushings = counter%tetr_pushings + local_counter%tetr_pushings
     counter%phi_0_mappings = counter%phi_0_mappings + local_counter%phi_0_mappings
     

--- a/TESTS/test_helical_core.py
+++ b/TESTS/test_helical_core.py
@@ -134,5 +134,8 @@ if result.returncode != 0:
 expected_marker = "Number of lost ions"
 if expected_marker not in result.stdout:
     sys.exit(f"FAIL: expected '{expected_marker}' in stdout but it was missing")
+boundary_marker = "Outer-boundary losses (field-aligned grids)"
+if boundary_marker not in result.stdout:
+    sys.exit(f"FAIL: expected '{boundary_marker}' in stdout but it was missing")
 
 print("PASS: helical core tracing completed and summary marker found")


### PR DESCRIPTION
The field-aligned helical-core path now treats exits through the outer grid boundary as particle losses. The magnetic-axis-hole reflection is unchanged. This removes the random inward displacement and reinsertion, so boundary handling no longer consumes random numbers.

The aggregate summary reports field-aligned outer-boundary losses separately while retaining the total lost-ion count.

## Verification

Before: `ctest --test-dir /tmp/gorilla-applets-absorbing-boundary -R helical_core --output-on-failure` failed because the outer-loss diagnostic was absent.

After: `ctest --test-dir /tmp/gorilla-applets-absorbing-boundary --output-on-failure` passes 8/8 tests.

`fo` passes Static, Build, and Lint.