### PR TITLE
Reject unimplemented 3D potential updates

### DIFF
--- a/EXAMPLES/self_consistent_electric_field/self_consistent_ef.inp
+++ b/EXAMPLES/self_consistent_electric_field/self_consistent_ef.inp
@@ -40,7 +40,6 @@
 !
   !type of electric potential update
   !1 ... 1D 
-  !3 ... 3D 
   update_dimension = 1
 !
   !Simulated density of particles

--- a/INPUT/self_consistent_ef.inp
+++ b/INPUT/self_consistent_ef.inp
@@ -40,7 +40,6 @@
 !
   !type of electric potential update
   !1 ... 1D 
-  !3 ... 3D 
   update_dimension = 1
 !
   !Simulated density of particles

--- a/SRC/utils_self_consistent_ef_mod.f90
+++ b/SRC/utils_self_consistent_ef_mod.f90
@@ -70,10 +70,20 @@ subroutine read_self_consistent_electric_field_inp_into_type
 
     if (in%dynamic_density_time_factor.le.0.0_dp) &
         error stop 'dynamic_density_time_factor must be positive'
+    if (.not.supported_potential_update_dimension(in%update_dimension)) &
+        error stop 'only one-dimensional electric-potential updates are implemented'
 
     print *,'GORILLA_APPLETS: Loaded input data from self_consistent_ef.inp'
 
 end subroutine read_self_consistent_electric_field_inp_into_type
+
+elemental pure logical function supported_potential_update_dimension(update_dimension)
+
+    integer, intent(in) :: update_dimension
+
+    supported_potential_update_dimension = update_dimension.eq.1
+
+end function supported_potential_update_dimension
 
 elemental pure function charge_density_to_potential(rho, energy_eV, density, &
         boole_static_ne, dynamic_density_time_factor) result(phi)

--- a/TESTS/test_self_consistent_potential.f90
+++ b/TESTS/test_self_consistent_potential.f90
@@ -1,11 +1,17 @@
 program test_self_consistent_potential
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use constants, only: echarge, ev2erg
-    use utils_self_consistent_ef_mod, only: charge_density_to_potential
+    use utils_self_consistent_ef_mod, only: charge_density_to_potential, &
+        supported_potential_update_dimension
 
     implicit none
 
     real(dp) :: expected
+
+    if (.not.supported_potential_update_dimension(1)) &
+        error stop 'one-dimensional potential update was rejected'
+    if (supported_potential_update_dimension(3)) &
+        error stop 'unimplemented three-dimensional potential update was accepted'
 
     expected = 2.0_dp*3.5e3_dp*ev2erg/(echarge**2*4.0_dp)
     if (abs(charge_density_to_potential(2.0_dp, 3.5e3_dp, 4.0_dp, &


### PR DESCRIPTION
The self-consistent electric-field reader now rejects every `update_dimension` except 1. The input templates no longer advertise dimension 3. Previously, selecting 3 bypassed the only implemented branch and silently produced a zero potential increment.

This leaves the implemented one-dimensional charge-neutrality update, CGS normalization, boundary conditions, and default input unchanged. A real three-dimensional update remains separate work.

## Verification

Before: `test_self_consistent_potential` failed to compile because the supported-dimension predicate did not exist.

After: the fresh CMake build passes; `ctest --test-dir /tmp/gorilla-applets-reject-3d --output-on-failure` passes 9/9 tests; `fo` passes Static, Build, and Lint.